### PR TITLE
[chore/setup-coredata]: CoreData 기본 환경 설정

### DIFF
--- a/HaruDam/HaruDam/CoreData/HaruDamModel.xcdatamodeld/HaruDamModel.xcdatamodel/contents
+++ b/HaruDam/HaruDam/CoreData/HaruDamModel.xcdatamodeld/HaruDamModel.xcdatamodel/contents
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24299" systemVersion="24G90" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+    <entity name="UserProfile" representedClassName="UserProfile" syncable="YES" codeGenerationType="class">
+        <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="email" optional="YES" attributeType="String"/>
+        <attribute name="nickname" optional="YES" attributeType="String"/>
+    </entity>
+</model>

--- a/HaruDam/HaruDam/CoreData/PersistenceController.swift
+++ b/HaruDam/HaruDam/CoreData/PersistenceController.swift
@@ -1,0 +1,56 @@
+//
+//  PersistenceController.swift
+//  HaruDam
+//
+//  Created by 존진 on 11/17/25.
+//
+
+import CoreData
+
+struct PersistenceController {
+    static let shared = PersistenceController()
+    
+    // preview, test용
+    static var preview: PersistenceController = {
+        let controller = PersistenceController(inMemory: true)
+        let context = controller.container.viewContext
+        
+        // 더미 데이터
+        let sample = UserProfile(context: context)
+        sample.email = "preview@example.com"
+        sample.nickname = "프리뷰유저"
+        sample.createdAt = Date()
+        
+        do {
+            try context.save()
+        } catch {
+            let nsError = error as NSError
+            fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
+        }
+        
+        return controller
+    }()
+    
+    let container: NSPersistentContainer
+    
+    init(inMemory: Bool = false) {
+        container = NSPersistentContainer(name: "HaruDamModel")
+        
+        if inMemory {
+            // 테스트용: 메모리에 저장
+            if let description = container.persistentStoreDescriptions.first {
+                description.url = URL(fileURLWithPath: "/dev/null")
+            }
+        }
+        
+        container.loadPersistentStores { _, error in
+            if let error = error as NSError? {
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        }
+        
+        container.viewContext.automaticallyMergesChangesFromParent = true
+        container.viewContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+    }
+    
+}

--- a/HaruDam/HaruDam/HaruDamApp.swift
+++ b/HaruDam/HaruDam/HaruDamApp.swift
@@ -6,12 +6,18 @@
 //
 
 import SwiftUI
+import CoreData
 
 @main
 struct HaruDamApp: App {
+    // CoreData
+    let persistentController = PersistenceController.shared
+    
     var body: some Scene {
         WindowGroup {
             SplashView()
+                .environment(\.managedObjectContext,
+                              persistentController.container.viewContext)
         }
     }
 }

--- a/HaruDam/HaruDamTests/UserProfileCoreDataTests.swift
+++ b/HaruDam/HaruDamTests/UserProfileCoreDataTests.swift
@@ -1,0 +1,52 @@
+//
+//  UserProfileCoreDataTests.swift
+//  HaruDamTests
+//
+//  Created by 존진 on 11/17/25.
+//
+
+import XCTest
+import CoreData
+@testable import HaruDam
+
+final class UserProfileCoreDataTests: XCTestCase {
+
+    var persistenceController: PersistenceController!
+        var context: NSManagedObjectContext!
+
+        override func setUpWithError() throws {
+            try super.setUpWithError()
+
+            // 메모리 전용 Core Data 스택 사용 (디스크에 안 남음)
+            persistenceController = PersistenceController(inMemory: true)
+            context = persistenceController.container.viewContext
+        }
+
+        override func tearDownWithError() throws {
+            persistenceController = nil
+            context = nil
+            try super.tearDownWithError()
+        }
+
+        func testInsertAndFetchUserProfile() throws {
+            // 더미 데이터
+            let user = UserProfile(context: context)
+            user.email = "test@harudam.com"
+            user.nickname = "테스트유저"
+            user.createdAt = Date()
+
+            try context.save()
+
+            // UserProfile 조회
+            let request: NSFetchRequest<UserProfile> = UserProfile.fetchRequest()
+            request.sortDescriptors = [NSSortDescriptor(key: "createdAt", ascending: false)]
+
+            let results = try context.fetch(request)
+
+            // 검증
+            XCTAssertEqual(results.count, 1)
+            XCTAssertEqual(results.first?.email, "test@harudam.com")
+            XCTAssertEqual(results.first?.nickname, "테스트유저")
+        }
+
+}


### PR DESCRIPTION
## 🧩작업 내용
- CoreData 기반 로컬 저장소 환경 구성
- HaruDamModel.xcdatamodeld 생성 및 UserProfile 엔티티 추가
    - email, nickname, createdAt 속성 구성
- PersistenceController 추가
- HaruDamApp에서 managedObjectContext 환경값 주입
    - 전체 View에서 Core Data 사용 가능하도록 구성
- UserProfile 테스트 코드 작성

## 🚧 추후 작업할 내용 (미완성 부분)
<!-- 이슈 번호와 함께 향후 작업 예정인 내용을 작성해주세요 -->
<!-- 연결된 이슈가 있다면 작성해주세요 (예: #123) -->
<!-- 체크리스트 작성 (예: - [ ]) -->
- 회원가입 로직과 Core Data 연동
    - 회원가입 성공 시 UserProfile 저장 처리
- 앱 실행 시 UserProfile 조회 후 자동 로그인 흐름 구현
- 향후 Diary/Emotion 엔티티 추가 예정

## 📷 스크린샷
<!-- UI 변경이 있는 경우 변경 전/후 스크린샷을 첨부해주세요 -->
.

## 🗒️ 기타 참고 사항
<!-- 리뷰어가 참고하면 좋을 추가 정보 -->
.