### PR TITLE
[feature/social-kakao]: 카카오 소셜 로그인 구현

### DIFF
--- a/HaruDam/HaruDam.xcodeproj/project.pbxproj
+++ b/HaruDam/HaruDam.xcodeproj/project.pbxproj
@@ -7,6 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8C69CAC22ECB60D2009701FB /* KakaoSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 8C69CAC12ECB60D2009701FB /* KakaoSDK */; };
+		8C69CAC42ECB60D2009701FB /* KakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 8C69CAC32ECB60D2009701FB /* KakaoSDKAuth */; };
+		8C69CAC62ECB60D2009701FB /* KakaoSDKCert in Frameworks */ = {isa = PBXBuildFile; productRef = 8C69CAC52ECB60D2009701FB /* KakaoSDKCert */; };
+		8C69CAC82ECB60D2009701FB /* KakaoSDKCertCore in Frameworks */ = {isa = PBXBuildFile; productRef = 8C69CAC72ECB60D2009701FB /* KakaoSDKCertCore */; };
+		8C69CACA2ECB60D2009701FB /* KakaoSDKCommon in Frameworks */ = {isa = PBXBuildFile; productRef = 8C69CAC92ECB60D2009701FB /* KakaoSDKCommon */; };
 		8CC7A4622EC2FC5C00C6B504 /* Auth in Frameworks */ = {isa = PBXBuildFile; productRef = 8CC7A4612EC2FC5C00C6B504 /* Auth */; };
 		8CC7A4662EC2FC5C00C6B504 /* PostgREST in Frameworks */ = {isa = PBXBuildFile; productRef = 8CC7A4652EC2FC5C00C6B504 /* PostgREST */; };
 		8CC7A46A2EC2FC5C00C6B504 /* Storage in Frameworks */ = {isa = PBXBuildFile; productRef = 8CC7A4692EC2FC5C00C6B504 /* Storage */; };
@@ -59,10 +64,15 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8C69CAC82ECB60D2009701FB /* KakaoSDKCertCore in Frameworks */,
 				8CC7A4662EC2FC5C00C6B504 /* PostgREST in Frameworks */,
+				8C69CAC22ECB60D2009701FB /* KakaoSDK in Frameworks */,
 				8CC7A5E42EC3107200C6B504 /* Supabase in Frameworks */,
+				8C69CACA2ECB60D2009701FB /* KakaoSDKCommon in Frameworks */,
 				8CC7A4622EC2FC5C00C6B504 /* Auth in Frameworks */,
 				8CC7A46A2EC2FC5C00C6B504 /* Storage in Frameworks */,
+				8C69CAC62ECB60D2009701FB /* KakaoSDKCert in Frameworks */,
+				8C69CAC42ECB60D2009701FB /* KakaoSDKAuth in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -126,6 +136,11 @@
 				8CC7A4652EC2FC5C00C6B504 /* PostgREST */,
 				8CC7A4692EC2FC5C00C6B504 /* Storage */,
 				8CC7A5E32EC3107200C6B504 /* Supabase */,
+				8C69CAC12ECB60D2009701FB /* KakaoSDK */,
+				8C69CAC32ECB60D2009701FB /* KakaoSDKAuth */,
+				8C69CAC52ECB60D2009701FB /* KakaoSDKCert */,
+				8C69CAC72ECB60D2009701FB /* KakaoSDKCertCore */,
+				8C69CAC92ECB60D2009701FB /* KakaoSDKCommon */,
 			);
 			productName = HaruDam;
 			productReference = 8CC7A12F2EBB212600C6B504 /* HaruDam.app */;
@@ -185,6 +200,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				8CC7A4602EC2FC5C00C6B504 /* XCRemoteSwiftPackageReference "supabase-swift" */,
+				8C69CAC02ECB60D2009701FB /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 8CC7A1302EBB212600C6B504 /* Products */;
@@ -512,6 +528,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		8C69CAC02ECB60D2009701FB /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kakao/kakao-ios-sdk";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.26.0;
+			};
+		};
 		8CC7A4602EC2FC5C00C6B504 /* XCRemoteSwiftPackageReference "supabase-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/supabase-community/supabase-swift.git";
@@ -523,6 +547,31 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		8C69CAC12ECB60D2009701FB /* KakaoSDK */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8C69CAC02ECB60D2009701FB /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDK;
+		};
+		8C69CAC32ECB60D2009701FB /* KakaoSDKAuth */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8C69CAC02ECB60D2009701FB /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKAuth;
+		};
+		8C69CAC52ECB60D2009701FB /* KakaoSDKCert */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8C69CAC02ECB60D2009701FB /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKCert;
+		};
+		8C69CAC72ECB60D2009701FB /* KakaoSDKCertCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8C69CAC02ECB60D2009701FB /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKCertCore;
+		};
+		8C69CAC92ECB60D2009701FB /* KakaoSDKCommon */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8C69CAC02ECB60D2009701FB /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKCommon;
+		};
 		8CC7A4612EC2FC5C00C6B504 /* Auth */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 8CC7A4602EC2FC5C00C6B504 /* XCRemoteSwiftPackageReference "supabase-swift" */;

--- a/HaruDam/HaruDam.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/HaruDam/HaruDam.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,24 @@
 {
-  "originHash" : "497b223336ae156cc4edd8c12c3d176b975452a34540e6bdf0a3cf91a248bc9c",
+  "originHash" : "4d362b2e364a169a676e5e4510f180a8d9a00ec5d2d575fe0141600937d64d78",
   "pins" : [
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "513364f870f6bfc468f9d2ff0a95caccc10044c5",
+        "version" : "5.10.2"
+      }
+    },
+    {
+      "identity" : "kakao-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao/kakao-ios-sdk",
+      "state" : {
+        "revision" : "f04b5655f3528e8c21a0ff7db047eeb138135394",
+        "version" : "2.26.0"
+      }
+    },
     {
       "identity" : "supabase-swift",
       "kind" : "remoteSourceControl",

--- a/HaruDam/HaruDam/Domain/User.swift
+++ b/HaruDam/HaruDam/Domain/User.swift
@@ -1,0 +1,20 @@
+//
+//  User.swift
+//  HaruDam
+//
+//  Created by 존진 on 11/19/25.
+//
+
+import Foundation
+
+struct User: Codable {
+    let id: String
+    let nickname: String?
+    let createdAt: Date
+    
+    enum CodingKeys: String, CodingKey {
+        case id
+        case nickname
+        case createdAt = "created_at"
+    }
+}

--- a/HaruDam/HaruDam/Features/SignUp/View/SignUpView.swift
+++ b/HaruDam/HaruDam/Features/SignUp/View/SignUpView.swift
@@ -11,6 +11,7 @@ import AuthenticationServices
 struct SignUpView: View {
 
     @Environment(\.colorScheme) var colorScheme: ColorScheme
+    @StateObject private var viewModel = SignUpViewModel()
     
     var body: some View {
         ZStack {
@@ -118,7 +119,7 @@ struct SignUpView: View {
                     
                     // Kakao
                     Button {
-                        
+                        viewModel.kakaoLoginButtonTapped()
                     } label: {
                         HStack(spacing: 15) {
                             Image("kakao_logo")

--- a/HaruDam/HaruDam/Features/SignUp/View/SignUpView.swift
+++ b/HaruDam/HaruDam/Features/SignUp/View/SignUpView.swift
@@ -11,7 +11,7 @@ import AuthenticationServices
 struct SignUpView: View {
 
     @Environment(\.colorScheme) var colorScheme: ColorScheme
-    @StateObject private var viewModel = SignUpViewModel()
+    @StateObject private var viewModel = SignUpViewModel(supabaseManager: .shared)
     
     var body: some View {
         ZStack {

--- a/HaruDam/HaruDam/Features/SignUp/ViewModel/SignUpViewModel.swift
+++ b/HaruDam/HaruDam/Features/SignUp/ViewModel/SignUpViewModel.swift
@@ -1,0 +1,48 @@
+//
+//  SignUpViewModel.swift
+//  HaruDam
+//
+//  Created by 존진 on 11/18/25.
+//
+
+import Foundation
+import Combine
+import Auth
+
+@MainActor
+class SignUpViewModel: ObservableObject {
+    @Published var isLoading: Bool = false
+    @Published var errorMessage: String? = nil
+    
+    // 로그인 성공 시 상위에서 화면 전환할 때 사용
+    var onLoginSuccess: (() -> Void)?
+    
+    private let supabaseManager: SupabaseManager
+    
+    init(supabaseManager: SupabaseManager = .shared) {
+            self.supabaseManager = supabaseManager
+    }
+    
+    func kakaoLoginButtonTapped() {
+        Task {
+            await kakaoLogin()
+        }
+    }
+    
+    private func kakaoLogin() async {
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+        
+        do {
+            // Supabase를 통해 카카오 OAuth 로그인
+            let response = try await supabaseManager.signInWithKakao()
+            
+            // TODO: 여기서 로그인된 유저 정보 저장/전달 (필요 시)
+            onLoginSuccess?()
+        } catch {
+            errorMessage = "카카오 로그인에 실패했어요. 잠시 후 다시 시도해주세요."
+        }
+    }
+    
+}

--- a/HaruDam/HaruDam/Features/SignUp/ViewModel/SignUpViewModel.swift
+++ b/HaruDam/HaruDam/Features/SignUp/ViewModel/SignUpViewModel.swift
@@ -19,9 +19,11 @@ class SignUpViewModel: ObservableObject {
     
     private let supabaseManager: SupabaseManager
     
-    init(supabaseManager: SupabaseManager = .shared) {
-            self.supabaseManager = supabaseManager
+    init(supabaseManager: SupabaseManager) {
+        self.supabaseManager = supabaseManager
     }
+    
+    private var authService: AuthService = AuthService()
     
     func kakaoLoginButtonTapped() {
         Task {
@@ -35,10 +37,8 @@ class SignUpViewModel: ObservableObject {
         defer { isLoading = false }
         
         do {
-            // Supabase를 통해 카카오 OAuth 로그인
-            let response = try await supabaseManager.signInWithKakao()
+            _ = try await authService.signInWithKakaoAndEnsureUser()
             
-            // TODO: 여기서 로그인된 유저 정보 저장/전달 (필요 시)
             onLoginSuccess?()
         } catch {
             errorMessage = "카카오 로그인에 실패했어요. 잠시 후 다시 시도해주세요."

--- a/HaruDam/HaruDam/Info.plist
+++ b/HaruDam/HaruDam/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>KAKAO_NATIVE_APP_KEY</key>
+	<string>$(KAKAO_NATIVE_APP_KEY)</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/HaruDam/HaruDam/Info.plist
+++ b/HaruDam/HaruDam/Info.plist
@@ -2,13 +2,30 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>UIAppFonts</key>
+	<key>CFBundleURLTypes</key>
 	<array>
-		<string>Roboto-Medium.ttf</string>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kakao$(KAKAO_NATIVE_APP_KEY)</string>
+			</array>
+		</dict>
+	</array>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaokompassauth</string>
+		<string>kakaolink</string>
+		<string>kakaotalk</string>
 	</array>
 	<key>SUPABASE_ANON_KEY</key>
 	<string>$(SUPABASE_ANON_KEY)</string>
 	<key>SUPABASE_URL</key>
 	<string>$(SUPABASE_URL)</string>
+	<key>UIAppFonts</key>
+	<array>
+		<string>Roboto-Medium.ttf</string>
+	</array>
 </dict>
 </plist>

--- a/HaruDam/HaruDam/Services/AuthService.swift
+++ b/HaruDam/HaruDam/Services/AuthService.swift
@@ -1,0 +1,91 @@
+//
+//  AuthService.swift
+//  HaruDam
+//
+//  Created by 존진 on 11/19/25.
+//
+
+import Foundation
+import Auth
+import Supabase
+
+final class AuthService {
+    
+    private let supabase: SupabaseManager
+    
+    init(supabase: SupabaseManager = .shared) {
+        self.supabase = supabase
+    }
+    
+    func signInWithKakao() async throws -> Session {
+        try await supabase.client.auth.signInWithOAuth(provider: .kakao,
+                                                       redirectTo: URL(string: SupabaseManager.Auth.appRedirect))
+    }
+    
+    /// 카카오 로그인 + user 테이블 자동 가입
+    func signInWithKakaoAndEnsureUser() async throws -> Session {
+        // Supabase Auth 카카오 로그인
+        let session = try await signInWithKakao()
+        
+        let authUser = session.user
+        
+        // DB에 유저 row 없으면 생성
+        try await ensureUserExists(for: authUser)
+        
+        return session
+    }
+    
+    // MARK: - Private
+    
+    /// Supabase DB의 user 테이블에 아직 row가 없으면 새로 생성
+    private func ensureUserExists(for authUser: Auth.User) async throws {
+        let userId = authUser.id.uuidString
+        
+        // 이미 있는지 조회
+        let existing: [User] = try await supabase.client
+            .from("user")
+            .select()
+            .eq("id", value: userId)
+            .limit(1)
+            .execute()
+            .value
+        
+        if !existing.isEmpty {
+            // 기존 회원이면 패스
+            return
+        }
+        
+        let rawName = authUser.userMetadata["name"]
+            ?? authUser.userMetadata["user_name"]
+
+        let nickname: String
+        if let rawName {
+            let nameString = String(describing: rawName).trimmingCharacters(in: .whitespacesAndNewlines)
+            nickname = nameString.isEmpty ? "새로운 기록자" : nameString
+        } else {
+            nickname = "새로운 기록자"
+        }
+        
+        let newUser = User(
+            id: userId,
+            nickname: nickname,
+            createdAt: Date()
+        )
+        
+        do {
+            _ = try await supabase.client
+                .from("user")
+                .insert(newUser)
+                .execute()
+        } catch {
+            print("[AuthService] insert user failed:", error)
+            throw error
+        }
+    }
+}
+
+// MARK: - Error
+
+enum AuthServiceError: Error {
+    case missingUser
+}

--- a/HaruDam/HaruDam/Utils/SupabaseManager.swift
+++ b/HaruDam/HaruDam/Utils/SupabaseManager.swift
@@ -37,8 +37,4 @@ final class SupabaseManager {
         static let appRedirect = "harudam://auth-callback"
     }
     
-    func signInWithKakao() async throws -> Session {
-        try await client.auth.signInWithOAuth(provider: .kakao,
-                                              redirectTo: URL(string: Auth.appRedirect))
-    }
 }

--- a/HaruDam/HaruDam/Utils/SupabaseManager.swift
+++ b/HaruDam/HaruDam/Utils/SupabaseManager.swift
@@ -20,6 +20,7 @@ final class SupabaseManager {
         guard
             let urlString = Bundle.main.object(forInfoDictionaryKey: "SUPABASE_URL") as? String,
             let key = Bundle.main.object(forInfoDictionaryKey: "SUPABASE_ANON_KEY") as? String,
+            let kakaoKey = Bundle.main.object(forInfoDictionaryKey: "KAKAO_NATIVE_APP_KEY") as? String,
             let url = URL(string: urlString)
         else {
             fatalError("Supabase 환경 변수를 불러올 수 없습니다.")

--- a/HaruDam/HaruDam/Utils/SupabaseManager.swift
+++ b/HaruDam/HaruDam/Utils/SupabaseManager.swift
@@ -20,7 +20,7 @@ final class SupabaseManager {
         guard
             let urlString = Bundle.main.object(forInfoDictionaryKey: "SUPABASE_URL") as? String,
             let key = Bundle.main.object(forInfoDictionaryKey: "SUPABASE_ANON_KEY") as? String,
-            let kakaoKey = Bundle.main.object(forInfoDictionaryKey: "KAKAO_NATIVE_APP_KEY") as? String,
+            let _ = Bundle.main.object(forInfoDictionaryKey: "KAKAO_NATIVE_APP_KEY") as? String,
             let url = URL(string: urlString)
         else {
             fatalError("Supabase 환경 변수를 불러올 수 없습니다.")
@@ -29,5 +29,16 @@ final class SupabaseManager {
         self.supabaseURL = url
         self.supabaseKey = key
         self.client = SupabaseClient(supabaseURL: url, supabaseKey: key)
+    }
+    
+    // MARK: - Auth Redirect
+    enum Auth {
+        /// 앱 복귀용 URL
+        static let appRedirect = "harudam://auth-callback"
+    }
+    
+    func signInWithKakao() async throws -> Session {
+        try await client.auth.signInWithOAuth(provider: .kakao,
+                                              redirectTo: URL(string: Auth.appRedirect))
     }
 }


### PR DESCRIPTION
## 🧩작업 내용
- 카카오 소셜 로그인 기반 로직 추가
    - Kakao SDK 의존성 추가
- Supabase 연동 및 Auth 서비스 계층 분리
    - 'AuthService' 추가
    -  로그인 성공 시 Supabase Auth의 'Auth.User' 정보를 활용해 DB 'user' 테이블에 자동 회원가입 처리
- 도메인 모델 추가
    - Supabase DB 'user' 테이블과 매핑되는 'User' 도메인 모델 정의
    - `id`, `nickname`, `createdAt` 필드 매핑 (`created_at` → `createdAt`)
 

### 🚧 추후 작업할 내용 (미완성 부분)
<!-- 이슈 번호와 함께 향후 작업 예정인 내용을 작성해주세요 -->
<!-- 연결된 이슈가 있다면 작성해주세요 (예: #123) -->
<!-- 체크리스트 작성 (예: - [ ]) -->

- 전역 App 상태 관리 도입( #7)
  - `AppViewModel`를 이용해 `isLoggedIn` 상태를 전역에서 관리
  - HaruDamApp 진입점에서 `isLoggedIn` 여부에 따라 `SignUpView` / `HomeView` 루트 분기
  - 현재 브랜치에서는 콜백(`onLoginSuccess`)까지만 구현, 실제 홈 화면 전환 로직은 별도 브랜치에서 진행 예정

- `HomeView` 화면 구현( #8)
  - 로그인 이후 진입할 홈 화면 기본 레이아웃 및 데이터 연동
  - 감정 기록/일기/배지 등 실제 기능과 연계는 추후 단계에서 추가

- 다른 소셜 로그인 확장
  - Kakao 외에 Google / Apple 등 OAuth Provider 추가
  - `AuthService` 확장 또는 Provider별 Service 분리 여부 검토


## 📷 스크린샷
<!-- UI 변경이 있는 경우 변경 전/후 스크린샷을 첨부해주세요 -->
.

## 🗒️ 기타 참고 사항
<!-- 리뷰어가 참고하면 좋을 추가 정보 -->
- 카카오 로그인 성공 시 Supabase Auth 기준으로는 이미 “회원가입 + 로그인”이 완료된 상태이며,
  앱 DB의 `user` 테이블에 유저 row가 없으면 자동으로 생성하는 형태로 간편 회원가입이 동작합니다.
- 홈 화면 전환 및 전역 로그인 상태 관리는 이후 브랜치에서 `AppViewModel`를 도입하여 정리할 예정입니다.