### PR TITLE
[feature/app-viewmodel]: 전역 앱 상태 관리용 AppViewModel 구현

### DIFF
--- a/HaruDam/HaruDam/Features/Home/View/HomeView.swift
+++ b/HaruDam/HaruDam/Features/Home/View/HomeView.swift
@@ -1,0 +1,18 @@
+//
+//  HomeView.swift
+//  HaruDam
+//
+//  Created by 존진 on 11/24/25.
+//
+
+import SwiftUI
+
+struct HomeView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    HomeView()
+}

--- a/HaruDam/HaruDam/Features/SignUp/View/SignUpView.swift
+++ b/HaruDam/HaruDam/Features/SignUp/View/SignUpView.swift
@@ -11,6 +11,7 @@ import AuthenticationServices
 struct SignUpView: View {
 
     @Environment(\.colorScheme) var colorScheme: ColorScheme
+    @EnvironmentObject var appViewModel: AppViewModel
     @StateObject private var viewModel = SignUpViewModel(supabaseManager: .shared)
     
     var body: some View {
@@ -141,6 +142,11 @@ struct SignUpView: View {
                 .padding(.horizontal, 24)
                 .buttonStyle(.plain) 
                 Spacer()
+            }
+        }
+        .onAppear {
+            viewModel.onLoginSuccess = {
+                appViewModel.isLoggedIn = true
             }
         }
     }

--- a/HaruDam/HaruDam/HaruDamApp.swift
+++ b/HaruDam/HaruDam/HaruDamApp.swift
@@ -10,14 +10,23 @@ import CoreData
 
 @main
 struct HaruDamApp: App {
+    @StateObject private var appViewModel = AppViewModel()
     // CoreData
     let persistentController = PersistenceController.shared
     
     var body: some Scene {
         WindowGroup {
-            SplashView()
-                .environment(\.managedObjectContext,
-                              persistentController.container.viewContext)
+            Group {
+                if appViewModel.isLoggedIn {
+                    HomeView()
+                } else {
+                    SplashView()
+                }
+            }
+            .environmentObject(appViewModel)
+            .environment(\.managedObjectContext,
+                          persistentController.container.viewContext)
         }
+        
     }
 }

--- a/HaruDam/HaruDam/Managers/AppViewModel.swift
+++ b/HaruDam/HaruDam/Managers/AppViewModel.swift
@@ -1,0 +1,14 @@
+//
+//  AppViewModel.swift
+//  HaruDam
+//
+//  Created by 존진 on 11/24/25.
+//
+
+import Foundation
+import Combine
+
+@MainActor
+final class AppViewModel: ObservableObject {
+    @Published var isLoggedIn: Bool = false
+}


### PR DESCRIPTION
## 🧩 작업 내용
- 전역 앱 상태 관리용 AppViewModel 추가(Managers/AppViewModel.swift)
  - `@MainActor` + `ObservableObject` 기반으로 구현
  - `@Published var isLoggedIn` 필드로 로그인 여부를 전역에서 관리하도록 설계

- HaruDamApp에서 루트 화면 분기 구조 적용
  - `isLoggedIn` 값에 따라 `SplashView` / `HomeView` 루트 분기
  - `Group`에 `.environmentObject(appViewModel)` 및 `.environment(\.managedObjectContext, ...)`를 걸어 전체 뷰 트리에서 공통으로 사용 가능하도록 정리

- SignUpView와 AppViewModel 연동
  - `viewModel.onLoginSuccess` 콜백에서 `appViewModel.isLoggedIn = true` 값을 변경해 로그인 성공 시 홈 화면으로 전환될 수 있도록 연결
  - 카카오 로그인 자체 로직은 `feature/social-kakao`에서 구현, 해당 브랜치에서는 전역 상태와 화면 전환만 담당


## 🚧 추후 작업할 내용 (미완성 부분)
<!-- 이슈 번호와 함께 향후 작업 예정인 내용을 작성해주세요 -->
<!-- 연결된 이슈가 있다면 작성해주세요 (예: #123) -->
<!-- 체크리스트 작성 (예: - [ ]) -->
- HomeView 기본 레이아웃 구현(#8)
  - 로그인 이후 실제로 진입할 홈 화면 UI 및 데이터 바인딩
  - AppViewModel과의 연동(로그아웃 버튼 등) 추가


## 📷 스크린샷
<!-- UI 변경이 있는 경우 변경 전/후 스크린샷을 첨부해주세요 -->
.

## 🗒️ 기타 참고 사항
<!-- 리뷰어가 참고하면 좋을 추가 정보 -->
- 소셜 로그인(카카오) 플로우는 `feature/social-kakao` 브랜치에서 구현 완료,  
  이번 PR은 그 플로우와 앱 전역 루트 화면 전환 구조(AppViewModel)를 연결하는 역할을 합니다.
- 향후 Google/Apple 로그인 추가 및 온보딩/홈 화면 확장 시에도 AppViewModel을 통해
  로그인 상태 기반 흐름 제어가 가능하도록 구조를 잡았습니다.
close #7 