### PR TITLE
[feature/auth-data-sync]: Supabase 인증 정보와 앱 전역 데이터 연동

### DIFF
--- a/HaruDam/HaruDam.xcodeproj/project.pbxproj
+++ b/HaruDam/HaruDam.xcodeproj/project.pbxproj
@@ -104,6 +104,7 @@
 		8CA9213E2ED87CAD00E4852B /* Sections */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Sections; sourceTree = "<group>"; };
 		8CA9214D2ED993D600E4852B /* Record */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Record; sourceTree = "<group>"; };
 		8CA9214F2ED993EA00E4852B /* Profile */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Profile; sourceTree = "<group>"; };
+		8CA921932EEAFBEC00E4852B /* Shared */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Shared; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -297,6 +298,7 @@
 		CF9730CA0643A7DF2336B557 /* HaruDam */ = {
 			isa = PBXGroup;
 			children = (
+				8CA921932EEAFBEC00E4852B /* Shared */,
 				8CE3F7E89F3EB36430039FFE /* Components */,
 				F06AF7C47EBE114236F0DA7E /* Config */,
 				CF68A177CAAFED0DB2034F0A /* CoreData */,
@@ -385,6 +387,7 @@
 				8CA9213E2ED87CAD00E4852B /* Sections */,
 				8CA9214D2ED993D600E4852B /* Record */,
 				8CA9214F2ED993EA00E4852B /* Profile */,
+				8CA921932EEAFBEC00E4852B /* Shared */,
 			);
 			name = HaruDam;
 			packageProductDependencies = (

--- a/HaruDam/HaruDam/Features/Home/View/HomeView.swift
+++ b/HaruDam/HaruDam/Features/Home/View/HomeView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct HomeView: View {
     
-    var nickname: String = "사용자"
     @State private var isPresentingWriteView = false
     
     // TODO: 추후 ViewModel에서 관리
@@ -42,7 +41,7 @@ struct HomeView: View {
     private var scrollContent: some View {
         ScrollView(showsIndicators: false) {
             VStack(alignment: .leading, spacing: 24) {
-                HeaderSection(nickname: nickname)
+                HeaderSection()
                 TodayEmotionCardView(onTap: handleTodayEmotionTap)
                 WeeklyFlowSection(values: weeklyEmotions)
                 RecentEmotionSection(emotions: recentEmotions)
@@ -63,7 +62,8 @@ struct HomeView: View {
 // MARK: - Header Section
 
 struct HeaderSection: View {
-    let nickname: String
+    
+    @EnvironmentObject private var authStore: AuthStore
     
     private var formattedToday: String {
         let formatter = DateFormatter()
@@ -74,7 +74,7 @@ struct HeaderSection: View {
     
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("안녕하세요 \(nickname)님")
+            Text("안녕하세요 \(authStore.displayUserName)님")
                 .font(.system(size: 28, weight: .bold))
             
             Text(formattedToday)

--- a/HaruDam/HaruDam/Features/Profile/Model/UserProfileModel.swift
+++ b/HaruDam/HaruDam/Features/Profile/Model/UserProfileModel.swift
@@ -1,0 +1,18 @@
+//
+//  UserProfile.swift
+//  HaruDam
+//
+//  Created by 존진 on 12/10/25.
+//  Copyright © 2025 kr.co.HaruDam. All rights reserved.
+//
+
+import Foundation
+
+struct UserProfileModel {
+    let id: String
+    let email: String
+    let nickname: String
+    let profileImageURL: URL?
+    let createdAt: Date?
+}
+

--- a/HaruDam/HaruDam/Features/Profile/Model/UserProfileResponseDTO.swift
+++ b/HaruDam/HaruDam/Features/Profile/Model/UserProfileResponseDTO.swift
@@ -1,0 +1,17 @@
+//
+//  UserProfileResponseDTO.swift
+//  HaruDam
+//
+//  Created by 존진 on 12/10/25.
+//  Copyright © 2025 kr.co.HaruDam. All rights reserved.
+//
+
+import Foundation
+
+struct UserProfileResponseDTO: Codable {
+    let id: String
+    let email: String
+    let nickname: String
+    let profileImageURL: String?
+    let createdAt: String?
+}

--- a/HaruDam/HaruDam/Features/Profile/Model/UserProfileResponseDTO.swift
+++ b/HaruDam/HaruDam/Features/Profile/Model/UserProfileResponseDTO.swift
@@ -15,3 +15,21 @@ struct UserProfileResponseDTO: Codable {
     let profileImageURL: String?
     let createdAt: String?
 }
+
+extension UserProfileResponseDTO {
+    func toModel() -> UserProfileModel {
+        let date: Date? = {
+            guard let createdAt else { return nil }
+            
+            let formatter = ISO8601DateFormatter()
+            return formatter.date(from: createdAt)
+        }()
+        
+        let imageURL: URL? = {
+            guard let profileImageURL else { return nil }
+            return URL(string: profileImageURL)
+        }()
+        
+        return UserProfileModel(id: id, email: email, nickname: nickname, profileImageURL: imageURL, createdAt: date)
+    }
+}

--- a/HaruDam/HaruDam/Features/Profile/Service/ProfileService.swift
+++ b/HaruDam/HaruDam/Features/Profile/Service/ProfileService.swift
@@ -7,7 +7,28 @@
 //
 
 import Foundation
+import Supabase
 
 protocol ProfileServiceProtocol {
     func fetchUserProfile(userId: String) async throws -> UserProfileModel
+}
+
+struct ProfileService: ProfileServiceProtocol {
+    let client: SupabaseClient
+
+    init(client: SupabaseClient = SupabaseManager.shared.client) {
+        self.client = client
+    }
+
+    func fetchUserProfile(userId: String) async throws -> UserProfileModel {
+        let dto: UserProfileResponseDTO = try await client
+            .from("profiles")
+            .select()
+            .eq("id", value: userId)
+            .single()
+            .execute()
+            .value
+
+        return dto.toModel()
+    }
 }

--- a/HaruDam/HaruDam/Features/Profile/Service/ProfileService.swift
+++ b/HaruDam/HaruDam/Features/Profile/Service/ProfileService.swift
@@ -1,0 +1,13 @@
+//
+//  ProfileService.swift
+//  HaruDam
+//
+//  Created by 존진 on 12/10/25.
+//  Copyright © 2025 kr.co.HaruDam. All rights reserved.
+//
+
+import Foundation
+
+protocol ProfileServiceProtocol {
+    func fetchUserProfile(userId: String) async throws -> UserProfileModel
+}

--- a/HaruDam/HaruDam/Features/Profile/View/ProfileHeaderCardView.swift
+++ b/HaruDam/HaruDam/Features/Profile/View/ProfileHeaderCardView.swift
@@ -38,7 +38,7 @@ struct ProfileHeaderCardView: View {
                     Text(authStore.displayUserName)
                         .font(.headline)
                     
-                    Text(email)
+                    Text(authStore.displayEmail)
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }

--- a/HaruDam/HaruDam/Features/Profile/View/ProfileHeaderCardView.swift
+++ b/HaruDam/HaruDam/Features/Profile/View/ProfileHeaderCardView.swift
@@ -9,8 +9,9 @@
 import SwiftUI
 
 struct ProfileHeaderCardView: View {
-    // TODO: 나중에 ViewModel에서 주입
-    let nickname: String = "감정 기록자"
+    
+    @EnvironmentObject private var authStore: AuthStore
+    
     let email: String = "user@example.com"
     
     let totalRecords: Int = 45
@@ -34,7 +35,7 @@ struct ProfileHeaderCardView: View {
                 }
                 
                 VStack(alignment: .leading, spacing: 4) {
-                    Text(nickname)
+                    Text(authStore.displayUserName)
                         .font(.headline)
                     
                     Text(email)

--- a/HaruDam/HaruDam/HaruDamApp.swift
+++ b/HaruDam/HaruDam/HaruDamApp.swift
@@ -12,6 +12,7 @@ import GoogleSignIn
 @main
 struct HaruDamApp: App {
     @StateObject private var appViewModel = AppViewModel()
+    @StateObject private var authStore = AuthStore()
     // CoreData
     let persistentController = PersistenceController.shared
     
@@ -19,6 +20,7 @@ struct HaruDamApp: App {
         WindowGroup {
             RootView()
                 .environmentObject(appViewModel)
+                .environmentObject(authStore)
                 .environment(\.managedObjectContext,
                               persistentController.container.viewContext)
                 .onOpenURL { url in

--- a/HaruDam/HaruDam/HaruDamApp.swift
+++ b/HaruDam/HaruDam/HaruDamApp.swift
@@ -12,16 +12,22 @@ import GoogleSignIn
 @main
 struct HaruDamApp: App {
     @StateObject private var appViewModel = AppViewModel()
+    @EnvironmentObject private var authStore: AuthStore
     // CoreData
     let persistentController = PersistenceController.shared
     
     var body: some Scene {
         WindowGroup {
             Group {
-                if appViewModel.isLoggedIn {
+                if !authStore.isBootstrapped {
+                    // 앱 시작 직후 세션 확인
+                    SplashView()
+                } else if authStore.isLoggedIn {
+                    // 로그인 상태
                     MainTabView()
                 } else {
-                    SplashView()
+                    // 로그아웃 상태
+                    SignUpView()
                 }
             }
             .environmentObject(appViewModel)

--- a/HaruDam/HaruDam/HaruDamApp.swift
+++ b/HaruDam/HaruDam/HaruDamApp.swift
@@ -17,19 +17,13 @@ struct HaruDamApp: App {
     
     var body: some Scene {
         WindowGroup {
-            Group {
-                if appViewModel.isLoggedIn {
-                    MainTabView()
-                } else {
-                    SplashView()
+            RootView()
+                .environmentObject(appViewModel)
+                .environment(\.managedObjectContext,
+                              persistentController.container.viewContext)
+                .onOpenURL { url in
+                    GIDSignIn.sharedInstance.handle(url)
                 }
-            }
-            .environmentObject(appViewModel)
-            .environment(\.managedObjectContext,
-                          persistentController.container.viewContext)
-            .onOpenURL { url in
-                GIDSignIn.sharedInstance.handle(url)
-            }
         }
         
     }

--- a/HaruDam/HaruDam/HaruDamApp.swift
+++ b/HaruDam/HaruDam/HaruDamApp.swift
@@ -12,22 +12,16 @@ import GoogleSignIn
 @main
 struct HaruDamApp: App {
     @StateObject private var appViewModel = AppViewModel()
-    @EnvironmentObject private var authStore: AuthStore
     // CoreData
     let persistentController = PersistenceController.shared
     
     var body: some Scene {
         WindowGroup {
             Group {
-                if !authStore.isBootstrapped {
-                    // 앱 시작 직후 세션 확인
-                    SplashView()
-                } else if authStore.isLoggedIn {
-                    // 로그인 상태
+                if appViewModel.isLoggedIn {
                     MainTabView()
                 } else {
-                    // 로그아웃 상태
-                    SignUpView()
+                    SplashView()
                 }
             }
             .environmentObject(appViewModel)

--- a/HaruDam/HaruDam/Shared/AuthStore.swift
+++ b/HaruDam/HaruDam/Shared/AuthStore.swift
@@ -27,8 +27,16 @@ final class AuthStore: ObservableObject {
         return nil
     }
     
+    var email: String? {
+        session?.user.email
+    }
+    
     var displayUserName: String {
         userName ?? "사용자"
+    }
+    
+    var displayEmail: String {
+        email ?? ""
     }
     
     init(client: SupabaseClient = SupabaseManager.shared.client) {

--- a/HaruDam/HaruDam/Shared/AuthStore.swift
+++ b/HaruDam/HaruDam/Shared/AuthStore.swift
@@ -17,6 +17,16 @@ final class AuthStore: ObservableObject {
     private let client: SupabaseClient
     private var authTask: Task<Void, Never>?
     
+    var userName: String? {
+        guard let value = session?.user.userMetadata["name"] as? AnyJSON else { return nil }
+        
+        if case let .string(name) = value {
+            return name
+        }
+        
+        return nil
+    }
+    
     init(client: SupabaseClient = SupabaseManager.shared.client) {
         self.client = client
         

--- a/HaruDam/HaruDam/Shared/AuthStore.swift
+++ b/HaruDam/HaruDam/Shared/AuthStore.swift
@@ -19,8 +19,22 @@ final class AuthStore: ObservableObject {
     
     init(client: SupabaseClient = SupabaseManager.shared.client) {
         self.client = client
+        authTask = Task {
+            await bootstrapSession()
+        }
     }
     
     var isLoggedIn: Bool { session != nil }
     var userId: String? { session?.user.id.uuidString }
+    
+    private func bootstrapSession() async {
+        do {
+            let session = try await client.auth.session
+            self.session = session
+        } catch {
+            self.session = nil
+        }
+
+        self.isBootstrapped = true
+    }
 }

--- a/HaruDam/HaruDam/Shared/AuthStore.swift
+++ b/HaruDam/HaruDam/Shared/AuthStore.swift
@@ -19,14 +19,21 @@ final class AuthStore: ObservableObject {
     
     init(client: SupabaseClient = SupabaseManager.shared.client) {
         self.client = client
+        
         authTask = Task {
             await bootstrapSession()
+            await listenAuthChanges()
         }
+    }
+    
+    deinit {
+        authTask?.cancel()
     }
     
     var isLoggedIn: Bool { session != nil }
     var userId: String? { session?.user.id.uuidString }
     
+    // 저장된 로그인 정보 확인
     private func bootstrapSession() async {
         do {
             let session = try await client.auth.session
@@ -36,5 +43,14 @@ final class AuthStore: ObservableObject {
         }
 
         self.isBootstrapped = true
+    }
+    
+    // 로그인 상태 변화 감시
+    private func listenAuthChanges() async {
+        await client.auth.onAuthStateChange { [weak self] _, session in
+            Task { @MainActor in
+                self?.session = session
+            }
+        }
     }
 }

--- a/HaruDam/HaruDam/Shared/AuthStore.swift
+++ b/HaruDam/HaruDam/Shared/AuthStore.swift
@@ -1,0 +1,23 @@
+//
+//  AuthStore.swift
+//  HaruDam
+//
+//  Created by 존진 on 12/15/25.
+//  Copyright © 2025 kr.co.HaruDam. All rights reserved.
+//
+
+import Foundation
+import Supabase
+
+@MainActor
+final class AuthStore: ObservableObject {
+    @Published private(set) var session: Session? = nil
+    @Published private(set) var isBootstrapped: Bool = false
+    
+    private let client: SupabaseClient
+    private var authTask: Task<Void, Never>?
+    
+    init(client: SupabaseClient = SupabaseManager.shared.client) {
+        self.client = client
+    }
+}

--- a/HaruDam/HaruDam/Shared/AuthStore.swift
+++ b/HaruDam/HaruDam/Shared/AuthStore.swift
@@ -27,6 +27,10 @@ final class AuthStore: ObservableObject {
         return nil
     }
     
+    var displayUserName: String {
+        userName ?? "사용자"
+    }
+    
     init(client: SupabaseClient = SupabaseManager.shared.client) {
         self.client = client
         

--- a/HaruDam/HaruDam/Shared/AuthStore.swift
+++ b/HaruDam/HaruDam/Shared/AuthStore.swift
@@ -20,4 +20,7 @@ final class AuthStore: ObservableObject {
     init(client: SupabaseClient = SupabaseManager.shared.client) {
         self.client = client
     }
+    
+    var isLoggedIn: Bool { session != nil }
+    var userId: String? { session?.user.id.uuidString }
 }

--- a/HaruDam/HaruDam/Shared/KeychainManager.swift
+++ b/HaruDam/HaruDam/Shared/KeychainManager.swift
@@ -1,0 +1,14 @@
+//
+//  KeychainManager.swift
+//  HaruDam
+//
+//  Created by 존진 on 12/11/25.
+//  Copyright © 2025 kr.co.HaruDam. All rights reserved.
+//
+
+import Foundation
+import Security
+
+final class KeychainManager {
+    
+}

--- a/HaruDam/HaruDam/Shared/KeychainManager.swift
+++ b/HaruDam/HaruDam/Shared/KeychainManager.swift
@@ -59,4 +59,19 @@ final class KeychainManager {
         
         return value
     }
+    
+    @discardableResult
+    func delete(for key: KeychainKey) -> Bool {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key.rawValue
+        ]
+        
+        let status = SecItemDelete(query as CFDictionary)
+        return status == errSecSuccess
+    }
+    
+    func clearAll() {
+        _ = delete(for: .userId)
+    }
 }

--- a/HaruDam/HaruDam/Shared/KeychainManager.swift
+++ b/HaruDam/HaruDam/Shared/KeychainManager.swift
@@ -9,6 +9,34 @@
 import Foundation
 import Security
 
+enum KeychainKey: String{
+    case userId
+}
+
 final class KeychainManager {
+    static let shared = KeychainManager()
+    private init() {}
     
+    @discardableResult
+    func save(_ value: String, for key: KeychainKey) -> Bool {
+        guard let data = value.data(using: .utf8) else { return false }
+        
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key.rawValue
+        ]
+        
+        // 기존 값 삭제
+        SecItemDelete(query as CFDictionary)
+        
+        // 새 값 추가
+        let attributes: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key.rawValue,
+            kSecValueData as String: data
+        ]
+        
+        let status = SecItemAdd(attributes as CFDictionary, nil)
+        return status == errSecSuccess
+    }
 }

--- a/HaruDam/HaruDam/Shared/KeychainManager.swift
+++ b/HaruDam/HaruDam/Shared/KeychainManager.swift
@@ -39,4 +39,24 @@ final class KeychainManager {
         let status = SecItemAdd(attributes as CFDictionary, nil)
         return status == errSecSuccess
     }
+    
+    func read(for key: KeychainKey) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key.rawValue,
+            kSecReturnData as String: kCFBooleanTrue as Any,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        
+        var item: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        
+        guard status == errSecSuccess,
+              let data = item as? Data,
+              let value = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        
+        return value
+    }
 }

--- a/HaruDam/HaruDam/Shared/Root/RootView.swift
+++ b/HaruDam/HaruDam/Shared/Root/RootView.swift
@@ -1,0 +1,9 @@
+//
+//  RootView.swift
+//  HaruDam
+//
+//  Created by 존진 on 12/18/25.
+//  Copyright © 2025 kr.co.HaruDam. All rights reserved.
+//
+
+import Foundation

--- a/HaruDam/HaruDam/Shared/Root/RootView.swift
+++ b/HaruDam/HaruDam/Shared/Root/RootView.swift
@@ -6,4 +6,11 @@
 //  Copyright © 2025 kr.co.HaruDam. All rights reserved.
 //
 
-import Foundation
+import SwiftUI
+
+struct RootView: View {
+    
+    var body: some View {
+        
+    }
+}

--- a/HaruDam/HaruDam/Shared/Root/RootView.swift
+++ b/HaruDam/HaruDam/Shared/Root/RootView.swift
@@ -9,8 +9,18 @@
 import SwiftUI
 
 struct RootView: View {
+    @EnvironmentObject private var authStore: AuthStore
     
     var body: some View {
-        
+        if !authStore.isBootstrapped {
+            // 앱 시작 후 세션 확인
+            SplashView()
+        } else if authStore.isLoggedIn {
+            // 로그인 상태
+            MainTabView()
+        } else {
+            // 로그아웃 상태
+            SignUpView()
+        }
     }
 }


### PR DESCRIPTION
## 🧩작업 내용
- Supabase Auth 세션 기준 로그인 상태를 관리하는 AuthStore 구현
- 앱 시작 시 세션 및 인증 상태 변화 감시 로직 추가
- RootView를 도입하여 로그인 / 로그아웃 / 스플래시 화면 분기 구조 정리
- Supabase userMetadata 및 session.user 정보를 앱 UI와 연동(Optional 처리된 display 전용 프로퍼티 제공)
    - 사용자 이름(displayUserName)
    - 사용자 이메일(displayEmail)
- 프로필 헤더 UI에서 하드코딩된 닉네임/이메일 제거 후 실제 로그인 사용자 정보 표시


## 🚧 추후 작업할 내용 (미완성 부분)
<!-- 이슈 번호와 함께 향후 작업 예정인 내용을 작성해주세요 -->
<!-- 연결된 이슈가 있다면 작성해주세요 (예: #123) -->
<!-- 체크리스트 작성 (예: - [ ]) -->
- 사용자 이름 수정 기능
- 프로필 통게 데이터 실제 데이터로 연동
- 로그아웃 시 로컬 상태 및 캐시 정리

## 📷 스크린샷
<!-- UI 변경이 있는 경우 변경 전/후 스크린샷을 첨부해주세요 -->
.


## 🗒️ 기타 참고 사항
<!-- 리뷰어가 참고하면 좋을 추가 정보 -->
- 로그인 상태의 Single Source of Truth는 AuthStore.session 입니다.
- View에서는 Supabase 구조를 직접 참조하지 않도록 설계했습니다.
- userMetadata의 name 값은 AnyJSON 타입이므로 .string 케이스 분해 방식으로 파싱했습니다.
- AuthStore는 @EnvironmentObject로 주입되어야 하며, Preview 사용시 주입 필요합니다.
- 기존 AppViewModel.isLoggedIn 기반 분기는 사용하지 않습니다.
