### PR TITLE
[feature/emotion-record]: 감정 기록 작성/조회/수정/삭제 및 Supabase 연동

### DIFF
--- a/HaruDam/EmotionRecordEntity+CoreDataClass.swift
+++ b/HaruDam/EmotionRecordEntity+CoreDataClass.swift
@@ -1,0 +1,17 @@
+//
+//  EmotionRecordEntity+CoreDataClass.swift
+//  
+//
+//  Created by 존진 on 1/15/26.
+//
+//
+
+public import Foundation
+public import CoreData
+
+public typealias EmotionRecordEntityCoreDataClassSet = NSSet
+
+@objc(EmotionRecordEntity)
+public class EmotionRecordEntity: NSManagedObject {
+
+}

--- a/HaruDam/EmotionRecordEntity+CoreDataProperties.swift
+++ b/HaruDam/EmotionRecordEntity+CoreDataProperties.swift
@@ -1,0 +1,31 @@
+//
+//  EmotionRecordEntity+CoreDataProperties.swift
+//  
+//
+//  Created by 존진 on 1/15/26.
+//
+//
+
+public import Foundation
+public import CoreData
+
+
+public typealias EmotionRecordEntityCoreDataPropertiesSet = NSSet
+
+extension EmotionRecordEntity {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<EmotionRecordEntity> {
+        return NSFetchRequest<EmotionRecordEntity>(entityName: "EmotionRecordEntity")
+    }
+
+    @NSManaged public var id: UUID?
+    @NSManaged public var emotion: String?
+    @NSManaged public var content: String?
+    @NSManaged public var createdAt: Date?
+    @NSManaged public var updatedAt: Date?
+    @NSManaged public var serverId: String?
+    @NSManaged public var tags: [String]?
+    @NSManaged public var syncStatus: String?
+    @NSManaged public var title: String?
+
+}

--- a/HaruDam/HaruDam.xcodeproj/project.pbxproj
+++ b/HaruDam/HaruDam.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		496DE70D988754C028EC2CCB /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = 48F89E3F86C3C0C43417D9D7 /* GoogleSignIn */; };
 		4CD91C4B89A277C782E22470 /* SignUpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E73DABA943C5E66C7F4D34B /* SignUpView.swift */; };
 		5A783CAC8E3AA76485DC97D2 /* Roboto-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 9F21F42E0199535EAA24D614 /* Roboto-Medium.ttf */; };
+		8C7FCBFC2F1F476300ABD93E /* EmotionRecordService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C7FCBFB2F1F476300ABD93E /* EmotionRecordService.swift */; };
 		8C9EAEEB2F18D331000BCFF1 /* EmotionRecordEntity+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C9EAEEA2F18D331000BCFF1 /* EmotionRecordEntity+CoreDataProperties.swift */; };
 		8C9EAEF52F18D344000BCFF1 /* EmotionRecordEntity+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C9EAEF42F18D344000BCFF1 /* EmotionRecordEntity+CoreDataClass.swift */; };
 		8C9EAF232F18D976000BCFF1 /* HaruDamModel.xcdatamodel in Sources */ = {isa = PBXBuildFile; fileRef = 8C9EAF222F18D976000BCFF1 /* HaruDamModel.xcdatamodel */; };
@@ -87,6 +88,7 @@
 		7D6C8A7FD3AC9046A2CFD2D9 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		7FF8E78649C6CB1BA22347BB /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
 		8337EA76B51F130D5915F74C /* RippleCircle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RippleCircle.swift; sourceTree = "<group>"; };
+		8C7FCBFB2F1F476300ABD93E /* EmotionRecordService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmotionRecordService.swift; sourceTree = "<group>"; };
 		8C9EAEEA2F18D331000BCFF1 /* EmotionRecordEntity+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EmotionRecordEntity+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		8C9EAEF42F18D344000BCFF1 /* EmotionRecordEntity+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EmotionRecordEntity+CoreDataClass.swift"; sourceTree = "<group>"; };
 		8C9EAF222F18D976000BCFF1 /* HaruDamModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = HaruDamModel.xcdatamodel; sourceTree = "<group>"; };
@@ -189,6 +191,7 @@
 			isa = PBXGroup;
 			children = (
 				B5C6ADB2CD02D28F4E01A39E /* AuthService.swift */,
+				8C7FCBFB2F1F476300ABD93E /* EmotionRecordService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -501,6 +504,7 @@
 				4CD91C4B89A277C782E22470 /* SignUpView.swift in Sources */,
 				8CA921522ED996E000E4852B /* EmotionRecord.swift in Sources */,
 				E6AEF0F27E3968CC78E50B0F /* SignUpViewModel.swift in Sources */,
+				8C7FCBFC2F1F476300ABD93E /* EmotionRecordService.swift in Sources */,
 				0D6FC1EB9FC12129088BC83A /* RippleCircle.swift in Sources */,
 				2C566A55581FE12C43267D83 /* SplashView.swift in Sources */,
 				8CA921482ED9924800E4852B /* MainTabView.swift in Sources */,

--- a/HaruDam/HaruDam.xcodeproj/project.pbxproj
+++ b/HaruDam/HaruDam.xcodeproj/project.pbxproj
@@ -20,7 +20,9 @@
 		496DE70D988754C028EC2CCB /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = 48F89E3F86C3C0C43417D9D7 /* GoogleSignIn */; };
 		4CD91C4B89A277C782E22470 /* SignUpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E73DABA943C5E66C7F4D34B /* SignUpView.swift */; };
 		5A783CAC8E3AA76485DC97D2 /* Roboto-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 9F21F42E0199535EAA24D614 /* Roboto-Medium.ttf */; };
-		799044E4460904F7A1805269 /* HaruDamModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 1541F0849CE6A47F20CDF064 /* HaruDamModel.xcdatamodeld */; };
+		8C9EAEEB2F18D331000BCFF1 /* EmotionRecordEntity+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C9EAEEA2F18D331000BCFF1 /* EmotionRecordEntity+CoreDataProperties.swift */; };
+		8C9EAEF52F18D344000BCFF1 /* EmotionRecordEntity+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C9EAEF42F18D344000BCFF1 /* EmotionRecordEntity+CoreDataClass.swift */; };
+		8C9EAF232F18D976000BCFF1 /* HaruDamModel.xcdatamodel in Sources */ = {isa = PBXBuildFile; fileRef = 8C9EAF222F18D976000BCFF1 /* HaruDamModel.xcdatamodel */; };
 		8CA921482ED9924800E4852B /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CA921472ED9924800E4852B /* MainTabView.swift */; };
 		8CA921522ED996E000E4852B /* EmotionRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CA921512ED996E000E4852B /* EmotionRecord.swift */; };
 		9DF46ED3887B8B7A601A09EC /* TuistFonts+HaruDam.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490D0720B26632DBAEC95BAB /* TuistFonts+HaruDam.swift */; };
@@ -85,6 +87,9 @@
 		7D6C8A7FD3AC9046A2CFD2D9 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		7FF8E78649C6CB1BA22347BB /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
 		8337EA76B51F130D5915F74C /* RippleCircle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RippleCircle.swift; sourceTree = "<group>"; };
+		8C9EAEEA2F18D331000BCFF1 /* EmotionRecordEntity+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EmotionRecordEntity+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		8C9EAEF42F18D344000BCFF1 /* EmotionRecordEntity+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EmotionRecordEntity+CoreDataClass.swift"; sourceTree = "<group>"; };
+		8C9EAF222F18D976000BCFF1 /* HaruDamModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = HaruDamModel.xcdatamodel; sourceTree = "<group>"; };
 		8CA921472ED9924800E4852B /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
 		8CA921512ED996E000E4852B /* EmotionRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmotionRecord.swift; sourceTree = "<group>"; };
 		9F21F42E0199535EAA24D614 /* Roboto-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Roboto-Medium.ttf"; sourceTree = "<group>"; };
@@ -97,7 +102,6 @@
 		DCD81377E42425EAAE3285AB /* HaruDamTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "HaruDamTests-Info.plist"; sourceTree = "<group>"; };
 		E4C8509434C5329FF38023AE /* PersistenceController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceController.swift; sourceTree = "<group>"; };
 		F298067425F4866065928E5A /* AppViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppViewModel.swift; sourceTree = "<group>"; };
-		FF01C4BEDD01EBA1A9DDD9E0 /* HaruDamModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = HaruDamModel.xcdatamodel; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -289,8 +293,10 @@
 		CF68A177CAAFED0DB2034F0A /* CoreData */ = {
 			isa = PBXGroup;
 			children = (
-				1541F0849CE6A47F20CDF064 /* HaruDamModel.xcdatamodeld */,
 				E4C8509434C5329FF38023AE /* PersistenceController.swift */,
+				8C9EAEEA2F18D331000BCFF1 /* EmotionRecordEntity+CoreDataProperties.swift */,
+				8C9EAEF42F18D344000BCFF1 /* EmotionRecordEntity+CoreDataClass.swift */,
+				8C9EAF222F18D976000BCFF1 /* HaruDamModel.xcdatamodel */,
 			);
 			path = CoreData;
 			sourceTree = "<group>";
@@ -483,6 +489,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				2600AF8D356250D1751B2D2C /* TuistAssets+HaruDam.swift in Sources */,
+				8C9EAEEB2F18D331000BCFF1 /* EmotionRecordEntity+CoreDataProperties.swift in Sources */,
+				8C9EAF232F18D976000BCFF1 /* HaruDamModel.xcdatamodel in Sources */,
+				8C9EAEF52F18D344000BCFF1 /* EmotionRecordEntity+CoreDataClass.swift in Sources */,
 				2F7A4C6EB64479636AEA32AA /* TuistBundle+HaruDam.swift in Sources */,
 				9DF46ED3887B8B7A601A09EC /* TuistFonts+HaruDam.swift in Sources */,
 				F7CBE1459227B227E87C521D /* LoadingView.swift in Sources */,
@@ -500,7 +509,6 @@
 				E20F8B21DD5188C6539045DE /* AuthService.swift in Sources */,
 				FCD8543B6B1C74CB737AB5EA /* AppColor.swift in Sources */,
 				051EB001675B19B03060D189 /* SupabaseManager.swift in Sources */,
-				799044E4460904F7A1805269 /* HaruDamModel.xcdatamodeld in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -822,19 +830,6 @@
 			productName = KakaoSDK;
 		};
 /* End XCSwiftPackageProductDependency section */
-
-/* Begin XCVersionGroup section */
-		1541F0849CE6A47F20CDF064 /* HaruDamModel.xcdatamodeld */ = {
-			isa = XCVersionGroup;
-			children = (
-				FF01C4BEDD01EBA1A9DDD9E0 /* HaruDamModel.xcdatamodel */,
-			);
-			currentVersion = FF01C4BEDD01EBA1A9DDD9E0 /* HaruDamModel.xcdatamodel */;
-			path = HaruDamModel.xcdatamodeld;
-			sourceTree = "<group>";
-			versionGroupType = wrapper.xcdatamodel;
-		};
-/* End XCVersionGroup section */
 	};
 	rootObject = FC26CD2713ADC91691BB4D8F /* Project object */;
 }

--- a/HaruDam/HaruDam.xcworkspace/contents.xcworkspacedata
+++ b/HaruDam/HaruDam.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,12 @@
 <Workspace
    version = "1.0">
    <FileRef
+      location = "group:EmotionRecordEntity+CoreDataClass.swift">
+   </FileRef>
+   <FileRef
+      location = "group:EmotionRecordEntity+CoreDataProperties.swift">
+   </FileRef>
+   <FileRef
       location = "group:HaruDam.xcodeproj">
    </FileRef>
 </Workspace>

--- a/HaruDam/HaruDam/CoreData/EmotionRecordEntity+CoreDataClass.swift
+++ b/HaruDam/HaruDam/CoreData/EmotionRecordEntity+CoreDataClass.swift
@@ -1,0 +1,17 @@
+//
+//  EmotionRecordEntity+CoreDataClass.swift
+//  
+//
+//  Created by 존진 on 1/15/26.
+//
+//
+
+public import Foundation
+public import CoreData
+
+public typealias EmotionRecordEntityCoreDataClassSet = NSSet
+
+@objc(EmotionRecordEntity)
+public class EmotionRecordEntity: NSManagedObject {
+
+}

--- a/HaruDam/HaruDam/CoreData/EmotionRecordEntity+CoreDataProperties.swift
+++ b/HaruDam/HaruDam/CoreData/EmotionRecordEntity+CoreDataProperties.swift
@@ -1,0 +1,31 @@
+//
+//  EmotionRecordEntity+CoreDataProperties.swift
+//  
+//
+//  Created by 존진 on 1/15/26.
+//
+//
+
+public import Foundation
+public import CoreData
+
+
+public typealias EmotionRecordEntityCoreDataPropertiesSet = NSSet
+
+extension EmotionRecordEntity {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<EmotionRecordEntity> {
+        return NSFetchRequest<EmotionRecordEntity>(entityName: "EmotionRecordEntity")
+    }
+
+    @NSManaged public var id: UUID?
+    @NSManaged public var emotion: String?
+    @NSManaged public var content: String?
+    @NSManaged public var createdAt: Date?
+    @NSManaged public var updatedAt: Date?
+    @NSManaged public var serverId: String?
+    @NSManaged public var tags: String?
+    @NSManaged public var syncStatus: String?
+    @NSManaged public var title: String?
+
+}

--- a/HaruDam/HaruDam/CoreData/HaruDamModel.xcdatamodel/contents
+++ b/HaruDam/HaruDam/CoreData/HaruDamModel.xcdatamodel/contents
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24411" systemVersion="25C56" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
-    <entity name="EmotionRecord" representedClassName="EmotionRecord" syncable="YES">
+    <entity name="EmotionRecordEntity" representedClassName="EmotionRecordEntity" syncable="YES">
         <attribute name="content" attributeType="String"/>
         <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="emotion" attributeType="String"/>
         <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="serverId" optional="YES" attributeType="String"/>
         <attribute name="syncStatus" attributeType="String" defaultValueString="pending"/>
-        <attribute name="tags" optional="YES" attributeType="Transformable" customClassName="[String]"/>
+        <attribute name="tags" optional="YES" attributeType="String" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="title" attributeType="String"/>
         <attribute name="updatedAt" attributeType="Date" usesScalarValueType="NO"/>
     </entity>
     <entity name="UserProfile" representedClassName="UserProfile" syncable="YES">

--- a/HaruDam/HaruDam/CoreData/HaruDamModel.xcdatamodeld/HaruDamModel.xcdatamodel/contents
+++ b/HaruDam/HaruDam/CoreData/HaruDamModel.xcdatamodeld/HaruDamModel.xcdatamodel/contents
@@ -1,8 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24299" systemVersion="24G90" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
-    <entity name="UserProfile" representedClassName="UserProfile" syncable="YES" codeGenerationType="class">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24411" systemVersion="25C56" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+    <entity name="EmotionRecord" representedClassName="EmotionRecord" syncable="YES">
+        <attribute name="content" attributeType="String"/>
+        <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="emotion" attributeType="String"/>
+        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="serverId" optional="YES" attributeType="String"/>
+        <attribute name="syncStatus" attributeType="String" defaultValueString="pending"/>
+        <attribute name="tags" optional="YES" attributeType="Transformable" customClassName="[String]"/>
+        <attribute name="updatedAt" attributeType="Date" usesScalarValueType="NO"/>
+    </entity>
+    <entity name="UserProfile" representedClassName="UserProfile" syncable="YES">
         <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="email" optional="YES" attributeType="String"/>
-        <attribute name="nickname" optional="YES" attributeType="String"/>
+        <attribute name="email" attributeType="String"/>
+        <attribute name="nickname" attributeType="String"/>
     </entity>
 </model>

--- a/HaruDam/HaruDam/CoreData/Harudam.xcdatamodeld/Harudam.xcdatamodel/contents
+++ b/HaruDam/HaruDam/CoreData/Harudam.xcdatamodeld/Harudam.xcdatamodel/contents
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24411" systemVersion="25C56" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+    <entity name="Entity" representedClassName="Entity" syncable="YES" codeGenerationType="class"/>
+</model>

--- a/HaruDam/HaruDam/CoreData/Harudam.xcdatamodeld/Harudam.xcdatamodel/contents
+++ b/HaruDam/HaruDam/CoreData/Harudam.xcdatamodeld/Harudam.xcdatamodel/contents
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24411" systemVersion="25C56" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
-    <entity name="Entity" representedClassName="Entity" syncable="YES" codeGenerationType="class"/>
-</model>

--- a/HaruDam/HaruDam/CoreData/PersistenceController.swift
+++ b/HaruDam/HaruDam/CoreData/PersistenceController.swift
@@ -14,13 +14,10 @@ struct PersistenceController {
     static var preview: PersistenceController = {
         let controller = PersistenceController(inMemory: true)
         let context = controller.container.viewContext
-        
-        // 더미 데이터
-        let sample = UserProfile(context: context)
-        sample.email = "preview@example.com"
-        sample.nickname = "프리뷰유저"
-        sample.createdAt = Date()
-        
+
+        // 더미 데이터는 엔티티 이름 변경/삭제 시 컴파일 에러가 날 수 있어,
+        // Preview 스토어는 기본 컨텍스트만 초기화합니다.
+
         do {
             try context.save()
         } catch {

--- a/HaruDam/HaruDam/Features/Record/View/EmotionRecordDetailView.swift
+++ b/HaruDam/HaruDam/Features/Record/View/EmotionRecordDetailView.swift
@@ -14,6 +14,8 @@ struct EmotionRecordDetailView: View {
     @Environment(\.managedObjectContext) private var context
     @State private var isDeleteAlertPresented: Bool = false
     
+    @StateObject private var viewModel: EmotionRecordEditViewModel
+    
     let record: EmotionRecordEntity
     var formatter: DateFormatter = {
         let f = DateFormatter()
@@ -21,6 +23,11 @@ struct EmotionRecordDetailView: View {
         f.dateFormat = "yyyy년 M월 d일 · EEEE"
         return f
     }()
+    
+    init(record: EmotionRecordEntity) {
+        self.record = record
+        _viewModel = StateObject(wrappedValue: EmotionRecordEditViewModel(record: record))
+    }
     
     var body: some View {
         ZStack {
@@ -81,24 +88,16 @@ struct EmotionRecordDetailView: View {
         }
         .alert("감정 기록 삭제", isPresented: $isDeleteAlertPresented) {
             Button("삭제", role: .destructive) {
-                deleteRecord()
+                Task {
+                    await viewModel.delete(context: context)
+                    dismiss()
+                }
             }
             Button("취소", role: .cancel) {}
         } message: {
             Text("이 감정 기록을 정말 삭제할까요? 삭제하면 되돌릴 수 없어요.")
         }
         .navigationBarTitleDisplayMode(.inline)
-    }
-    
-    private func deleteRecord() {
-        context.delete(record)
-        do {
-            try context.save()
-            dismiss()
-        } catch {
-            context.rollback()
-            print("Failed to delete record: \(error)")
-        }
     }
 }
 

--- a/HaruDam/HaruDam/Features/Record/View/EmotionRecordDetailView.swift
+++ b/HaruDam/HaruDam/Features/Record/View/EmotionRecordDetailView.swift
@@ -7,83 +7,63 @@
 //
 
 import SwiftUI
+import CoreData
 
 struct EmotionRecordDetailView: View {
     @Environment(\.dismiss) private var dismiss
-
-    let record: EmotionRecord
+    @FetchRequest(
+        sortDescriptors: [
+            NSSortDescriptor(keyPath: \EmotionRecordEntity.createdAt, ascending: false)
+        ],
+        animation: .default
+    )
+    private var records: FetchedResults<EmotionRecordEntity>
     private var formatter: DateFormatter = .init()
-
-    init(record: EmotionRecord) {
-        self.record = record
-        formatter.locale = Locale(identifier: "ko_KR")
-        formatter.dateFormat = "yyyy년 M월 d일 · EEEE"
-    }
-
+    
+    //    init(record: EmotionRecord) {
+    //        formatter.locale = Locale(identifier: "ko_KR")
+    //        formatter.dateFormat = "yyyy년 M월 d일 · EEEE"
+    //    }
+    
     var body: some View {
         ZStack {
             AppColor.background.ignoresSafeArea()
-
-            ScrollView(showsIndicators: false) {
-                VStack(alignment: .leading, spacing: 20) {
-                    // 제목 및 날짜
-                    VStack(alignment: .leading, spacing: 8) {
-                        HStack(spacing: 12) {
-                            ZStack {
-                                Circle()
-                                    .fill(AppColor.background)
-                                    .shadow(color: Color.black.opacity(0.03), radius: 8, x: 0, y: 4)
-
-                                Text(record.emoji)
-                                    .font(.system(size: 32))
+            
+            List {
+                if records.isEmpty {
+                    Text("아직 감정 기록이 없어요.")
+                        .foregroundColor(.secondary)
+                } else {
+                    ForEach(records) { record in
+                        VStack(alignment: .leading, spacing: 6) {
+                            HStack(spacing: 8) {
+                                Text(record.emotion ?? "🙂")
+                                    .font(.system(size: 24))
+                                
+                                Text(record.title ?? "")
+                                    .font(.system(size: 16, weight: .semibold))
                             }
-                            .frame(width: 64, height: 64)
-
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text(record.title)
-                                    .font(.system(size: 22, weight: .bold))
-                                    .foregroundColor(AppColor.textPrimary)
-
-                                Text(formatter.string(from: record.date))
-                                    .font(.system(size: 13))
-                                    .foregroundColor(AppColor.textSecondary)
-                            }
+                            
+                            Text(record.content ?? "")
+                                .font(.system(size: 14))
+                                .foregroundColor(.secondary)
+                                .lineLimit(2)
+                            
+                            Text(
+                                (record.createdAt ?? Date())
+                                    .formatted(date: .abbreviated, time: .omitted)
+                            )
+                            .font(.caption)
+                            .foregroundColor(.secondary)
                         }
+                        .padding(.vertical, 6)
                     }
-
-                    // 내용
-                    Text(record.description)
-                        .font(.system(size: 15))
-                        .foregroundColor(AppColor.textPrimary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.leading, 10)
-
-                    Spacer()
-                }
-                .padding(.horizontal, 20)
-                .padding(.top, 24)
-                .padding(.bottom, 32)
-            }
-        }
-        .navigationTitle("감정 기록")
-        .navigationBarTitleDisplayMode(.inline)
-        .navigationBarBackButtonHidden(true)
-        .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                Button(action: {
-                    dismiss()
-                }) {
-                    HStack(spacing: 4) {
-                        Image(systemName: "chevron.left")
-                            .font(.system(size: 16, weight: .semibold))
-                    }
-                    .foregroundColor(AppColor.textPrimary)
                 }
             }
+            .navigationTitle("감정 기록")
         }
     }
 }
 
-#Preview {
-    EmotionRecordDetailView(record: EmotionRecord.mockData.first!)
-}
+// MARK: - CoreData
+extension EmotionRecordEntity: Identifiable {}

--- a/HaruDam/HaruDam/Features/Record/View/EmotionRecordDetailView.swift
+++ b/HaruDam/HaruDam/Features/Record/View/EmotionRecordDetailView.swift
@@ -11,57 +11,58 @@ import CoreData
 
 struct EmotionRecordDetailView: View {
     @Environment(\.dismiss) private var dismiss
-    @FetchRequest(
-        sortDescriptors: [
-            NSSortDescriptor(keyPath: \EmotionRecordEntity.createdAt, ascending: false)
-        ],
-        animation: .default
-    )
-    private var records: FetchedResults<EmotionRecordEntity>
-    private var formatter: DateFormatter = .init()
-    
-    //    init(record: EmotionRecord) {
-    //        formatter.locale = Locale(identifier: "ko_KR")
-    //        formatter.dateFormat = "yyyy년 M월 d일 · EEEE"
-    //    }
+    let record: EmotionRecordEntity
+    var formatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "ko_KR")
+        f.dateFormat = "yyyy년 M월 d일 · EEEE"
+        return f
+    }()
     
     var body: some View {
         ZStack {
             AppColor.background.ignoresSafeArea()
-            
-            List {
-                if records.isEmpty {
-                    Text("아직 감정 기록이 없어요.")
-                        .foregroundColor(.secondary)
-                } else {
-                    ForEach(records) { record in
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    HStack(alignment: .top, spacing: 12) {
+                        Text(record.emotion ?? "🙂")
+                            .font(.system(size: 44))
+
                         VStack(alignment: .leading, spacing: 6) {
-                            HStack(spacing: 8) {
-                                Text(record.emotion ?? "🙂")
-                                    .font(.system(size: 24))
-                                
-                                Text(record.title ?? "")
-                                    .font(.system(size: 16, weight: .semibold))
-                            }
-                            
-                            Text(record.content ?? "")
-                                .font(.system(size: 14))
-                                .foregroundColor(.secondary)
-                                .lineLimit(2)
-                            
-                            Text(
-                                (record.createdAt ?? Date())
-                                    .formatted(date: .abbreviated, time: .omitted)
-                            )
-                            .font(.caption)
-                            .foregroundColor(.secondary)
+                            Text(record.title ?? "")
+                                .font(.system(size: 22, weight: .semibold))
+                                .foregroundColor(AppColor.textPrimary)
+
+                            Text(formatter.string(from: record.createdAt ?? Date()))
+                                .font(.system(size: 12))
+                                .foregroundColor(AppColor.textSecondary)
                         }
-                        .padding(.vertical, 6)
+
+                        Spacer()
                     }
+
+                    Divider()
+
+                    Text(record.content ?? "")
+                        .font(.system(size: 16))
+                        .foregroundColor(AppColor.textPrimary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .lineSpacing(4)
+
+                    Spacer(minLength: 0)
                 }
+                .padding(20)
+                .background(
+                    RoundedRectangle(cornerRadius: 16)
+                        .fill(Color.white)
+                )
+                .padding(.horizontal, 16)
+                .padding(.top, 16)
             }
-            .navigationTitle("감정 기록")
         }
+        .navigationTitle("감정 기록")
+        .navigationBarTitleDisplayMode(.inline)
     }
 }
 

--- a/HaruDam/HaruDam/Features/Record/View/EmotionRecordDetailView.swift
+++ b/HaruDam/HaruDam/Features/Record/View/EmotionRecordDetailView.swift
@@ -11,6 +11,8 @@ import CoreData
 
 struct EmotionRecordDetailView: View {
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.managedObjectContext) private var context
+    
     let record: EmotionRecordEntity
     var formatter: DateFormatter = {
         let f = DateFormatter()
@@ -62,7 +64,27 @@ struct EmotionRecordDetailView: View {
             }
         }
         .navigationTitle("감정 기록")
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button(role: .destructive){
+                    deleteRecord()
+                } label: {
+                    Image(systemName: "trash")
+                }
+            }
+        }
         .navigationBarTitleDisplayMode(.inline)
+    }
+    
+    private func deleteRecord() {
+        context.delete(record)
+        do {
+            try context.save()
+            dismiss()
+        } catch {
+            context.rollback()
+            print("Failed to delete record: \(error)")
+        }
     }
 }
 

--- a/HaruDam/HaruDam/Features/Record/View/EmotionRecordDetailView.swift
+++ b/HaruDam/HaruDam/Features/Record/View/EmotionRecordDetailView.swift
@@ -12,6 +12,7 @@ import CoreData
 struct EmotionRecordDetailView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.managedObjectContext) private var context
+    @State private var isDeleteAlertPresented: Bool = false
     
     let record: EmotionRecordEntity
     var formatter: DateFormatter = {
@@ -66,12 +67,20 @@ struct EmotionRecordDetailView: View {
         .navigationTitle("감정 기록")
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
-                Button(role: .destructive){
-                    deleteRecord()
+                Button(role: .destructive) {
+                    isDeleteAlertPresented = true
                 } label: {
                     Image(systemName: "trash")
                 }
             }
+        }
+        .alert("감정 기록 삭제", isPresented: $isDeleteAlertPresented) {
+            Button("삭제", role: .destructive) {
+                deleteRecord()
+            }
+            Button("취소", role: .cancel) {}
+        } message: {
+            Text("이 감정 기록을 정말 삭제할까요? 삭제하면 되돌릴 수 없어요.")
         }
         .navigationBarTitleDisplayMode(.inline)
     }

--- a/HaruDam/HaruDam/Features/Record/View/EmotionRecordDetailView.swift
+++ b/HaruDam/HaruDam/Features/Record/View/EmotionRecordDetailView.swift
@@ -66,7 +66,12 @@ struct EmotionRecordDetailView: View {
         }
         .navigationTitle("감정 기록")
         .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
+            ToolbarItemGroup(placement: .topBarTrailing) {
+                NavigationLink {
+                    EmotionRecordEditView(record: record)
+                } label: {
+                    Image(systemName: "pencil")
+                }
                 Button(role: .destructive) {
                     isDeleteAlertPresented = true
                 } label: {

--- a/HaruDam/HaruDam/Features/Record/View/EmotionRecordEditView.swift
+++ b/HaruDam/HaruDam/Features/Record/View/EmotionRecordEditView.swift
@@ -1,0 +1,75 @@
+//
+//  EmotionRecordEditView.swift
+//  HaruDam
+//
+//  Created by 존진 on 1/16/26.
+//  Copyright © 2026 kr.co.HaruDam. All rights reserved.
+//
+
+import SwiftUI
+import CoreData
+
+struct EmotionRecordEditView: View {
+    @Environment(\.managedObjectContext) private var context
+    @Environment(\.dismiss) private var dismiss
+    
+    let record: EmotionRecordEntity
+    
+    @State private var title: String
+    @State private var content: String
+    @State private var emotion: String
+    
+    init(record: EmotionRecordEntity) {
+        self.record = record
+        _title = State(initialValue: record.title ?? "")
+        _content = State(initialValue: record.content ?? "")
+        _emotion = State(initialValue: record.emotion ?? "🙂")
+    }
+    
+    var body: some View {
+        VStack(spacing: 16) {
+            // 감정(이모지) — 지금은 Text로, 나중에 Picker로 확장 가능
+            TextField("감정", text: $emotion)
+                .font(.system(size: 32))
+                .multilineTextAlignment(.center)
+            
+            TextField("제목", text: $title)
+                .textFieldStyle(.roundedBorder)
+            
+            TextEditor(text: $content)
+                .frame(minHeight: 200)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(Color.gray.opacity(0.2))
+                )
+            
+            Spacer()
+        }
+        .padding()
+        .navigationTitle("감정 기록 수정")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button("완료") {
+                    updateRecord()
+                }
+                .disabled(title.isEmpty || content.isEmpty)
+            }
+        }
+    }
+    
+    private func updateRecord() {
+        record.title = title
+        record.content = content
+        record.emotion = emotion
+        record.updatedAt = Date()
+        
+        do {
+            try context.save()
+            dismiss()
+        } catch {
+            context.rollback()
+            print("Failed to update record:", error)
+        }
+    }
+}

--- a/HaruDam/HaruDam/Features/Record/View/EmotionRecordEditView.swift
+++ b/HaruDam/HaruDam/Features/Record/View/EmotionRecordEditView.swift
@@ -20,25 +20,23 @@ struct EmotionRecordEditView: View {
     }
     
     var body: some View {
-        VStack(spacing: 16) {
-            // 감정(이모지) — 지금은 Text로, 나중에 Picker로 확장 가능
-            TextField("감정", text: $viewModel.emotion)
-                .font(.system(size: 32))
-                .multilineTextAlignment(.center)
-            
-            TextField("제목", text: $viewModel.title)
-                .textFieldStyle(.roundedBorder)
-            
-            TextEditor(text: $viewModel.content)
-                .frame(minHeight: 200)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 8)
-                        .stroke(Color.gray.opacity(0.2))
-                )
-            
-            Spacer()
+        ZStack {
+            AppColor.background.ignoresSafeArea()
+
+            ScrollView(showsIndicators: false) {
+                VStack(alignment: .leading, spacing: 24) {
+                    headerSection
+                    emojiSection
+                    titleSection
+                    contentSection
+
+                    Spacer(minLength: 0)
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 24)
+                .padding(.bottom, 40)
+            }
         }
-        .padding()
         .navigationTitle("감정 기록 수정")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
@@ -51,8 +49,119 @@ struct EmotionRecordEditView: View {
                         }
                     }
                 }
+                .foregroundColor(viewModel.canSave ? AppColor.primary : AppColor.textSecondary)
                 .disabled(!viewModel.canSave || viewModel.isSyncing)
             }
+        }
+    }
+    
+    // MARK: - Sections
+    private var headerSection: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("기록을 수정해볼까요?")
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundColor(AppColor.textPrimary)
+
+            Text("감정과 내용을 원하는 대로 바꿔볼 수 있어요.")
+                .font(.system(size: 13))
+                .foregroundColor(AppColor.textSecondary)
+        }
+    }
+
+    private var emojiSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("오늘의 감정")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundColor(AppColor.textPrimary)
+
+            HStack(spacing: 16) {
+                ZStack {
+                    Circle()
+                        .fill(AppColor.background)
+                        .shadow(color: Color.black.opacity(0.05), radius: 8, x: 0, y: 4)
+
+                    Text(viewModel.emotion)
+                        .font(.system(size: 32))
+                }
+                .frame(width: 64, height: 64)
+
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 12) {
+                        ForEach(["😌", "😊", "😢", "😡", "😰", "🤔", "🥰", "🤯"], id: \.self) { emoji in
+                            Button {
+                                viewModel.emotion = emoji
+                            } label: {
+                                Text(emoji)
+                                    .font(.system(size: 26))
+                                    .padding(10)
+                                    .background(
+                                        Circle()
+                                            .fill(viewModel.emotion == emoji
+                                                  ? AppColor.primary.opacity(0.15)
+                                                  : Color.white.opacity(0.9))
+                                    )
+                                    .overlay(
+                                        Circle()
+                                            .stroke(viewModel.emotion == emoji
+                                                    ? AppColor.primary
+                                                    : Color.clear, lineWidth: 1)
+                                    )
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var titleSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("감정 한 줄 제목")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundColor(AppColor.textPrimary)
+
+            TextField("제목을 입력해주세요", text: $viewModel.title)
+                .font(.system(size: 15))
+                .foregroundColor(AppColor.textPrimary)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .background(
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(Color.white.opacity(0.95))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(Color.black.opacity(0.03), lineWidth: 1)
+                )
+        }
+    }
+
+    private var contentSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("내용")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundColor(AppColor.textPrimary)
+
+            ZStack(alignment: .topLeading) {
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(Color.white.opacity(0.95))
+                    .shadow(color: Color.black.opacity(0.02), radius: 6, x: 0, y: 3)
+
+                TextEditor(text: $viewModel.content)
+                    .font(.system(size: 15))
+                    .foregroundColor(AppColor.textPrimary)
+                    .padding(12)
+                    .scrollContentBackground(.hidden)
+
+                if viewModel.content.isEmpty {
+                    Text("오늘 있었던 일이나 느낀 점을 자유롭게 적어보세요.")
+                        .font(.system(size: 14))
+                        .foregroundColor(AppColor.textSecondary)
+                        .padding(19)
+                }
+            }
+            .frame(minHeight: 200)
         }
     }
 }

--- a/HaruDam/HaruDam/Features/Record/View/EmotionRecordEditView.swift
+++ b/HaruDam/HaruDam/Features/Record/View/EmotionRecordEditView.swift
@@ -13,30 +13,23 @@ struct EmotionRecordEditView: View {
     @Environment(\.managedObjectContext) private var context
     @Environment(\.dismiss) private var dismiss
     
-    let record: EmotionRecordEntity
-    
-    @State private var title: String
-    @State private var content: String
-    @State private var emotion: String
+    @StateObject private var viewModel: EmotionRecordEditViewModel
     
     init(record: EmotionRecordEntity) {
-        self.record = record
-        _title = State(initialValue: record.title ?? "")
-        _content = State(initialValue: record.content ?? "")
-        _emotion = State(initialValue: record.emotion ?? "🙂")
+        _viewModel = StateObject(wrappedValue: EmotionRecordEditViewModel(record: record))
     }
     
     var body: some View {
         VStack(spacing: 16) {
             // 감정(이모지) — 지금은 Text로, 나중에 Picker로 확장 가능
-            TextField("감정", text: $emotion)
+            TextField("감정", text: $viewModel.emotion)
                 .font(.system(size: 32))
                 .multilineTextAlignment(.center)
             
-            TextField("제목", text: $title)
+            TextField("제목", text: $viewModel.title)
                 .textFieldStyle(.roundedBorder)
             
-            TextEditor(text: $content)
+            TextEditor(text: $viewModel.content)
                 .frame(minHeight: 200)
                 .overlay(
                     RoundedRectangle(cornerRadius: 8)
@@ -51,25 +44,15 @@ struct EmotionRecordEditView: View {
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 Button("완료") {
-                    updateRecord()
+                    Task {
+                        await viewModel.save(context: context)
+                        if viewModel.errorMessage == nil {
+                            dismiss()
+                        }
+                    }
                 }
-                .disabled(title.isEmpty || content.isEmpty)
+                .disabled(!viewModel.canSave || viewModel.isSyncing)
             }
-        }
-    }
-    
-    private func updateRecord() {
-        record.title = title
-        record.content = content
-        record.emotion = emotion
-        record.updatedAt = Date()
-        
-        do {
-            try context.save()
-            dismiss()
-        } catch {
-            context.rollback()
-            print("Failed to update record:", error)
         }
     }
 }

--- a/HaruDam/HaruDam/Features/Record/View/EmotionRecordWriteView.swift
+++ b/HaruDam/HaruDam/Features/Record/View/EmotionRecordWriteView.swift
@@ -28,7 +28,6 @@ struct EmotionRecordWriteView: View {
                         
                         headerSection
                         emojiSection
-                        dateSection
                         titleSection
                         contentSection
                         
@@ -122,22 +121,6 @@ struct EmotionRecordWriteView: View {
                     }
                 }
             }
-        }
-    }
-    
-    private var dateSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("날짜")
-                .font(.system(size: 15, weight: .semibold))
-                .foregroundColor(AppColor.textPrimary)
-            
-            DatePicker(
-                "",
-                selection: $viewModel.date,
-                displayedComponents: .date
-            )
-            .labelsHidden()
-            .tint(AppColor.primary)
         }
     }
     

--- a/HaruDam/HaruDam/Features/Record/View/EmotionRecordWriteView.swift
+++ b/HaruDam/HaruDam/Features/Record/View/EmotionRecordWriteView.swift
@@ -7,15 +7,19 @@
 //
 
 import SwiftUI
+import CoreData
 
 struct EmotionRecordWriteView: View {
 
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.presentationMode) private var presentationMode
+    @Environment(\.managedObjectContext) private var context
 
     @State private var selectedEmoji: String = "😌"
     @State private var title: String = ""
     @State private var date: Date = Date()
     @State private var content: String = ""
+    @State private var tags: [String] = []
 
     /// 저장 버튼 눌렀을 때 상위에서 처리할 수 있도록 콜백
     var onSave: ((String, String, Date, String) -> Void)?
@@ -197,8 +201,37 @@ struct EmotionRecordWriteView: View {
     // MARK: - 저장
     private func handleSave() {
         guard canSave else { return }
-        onSave?(selectedEmoji, title, date, content)
-        dismiss()
+
+        // CoreData(NSManagedObject) 엔티티에 저장
+        let newRecord = EmotionRecordEntity(context: context)
+        newRecord.id = UUID()
+        newRecord.title = title
+        newRecord.emotion = selectedEmoji
+        newRecord.content = content
+        newRecord.createdAt = date
+        newRecord.updatedAt = Date()
+
+        // Supabase 동기화용
+        newRecord.syncStatus = "pending"
+        newRecord.serverId = nil
+
+        let tagsJson: String
+        do {
+            let data = try JSONEncoder().encode(tags)
+            tagsJson = String(data: data, encoding: .utf8) ?? "[]"
+        } catch {
+            tagsJson = "[]"
+        }
+        newRecord.tags = tagsJson
+
+        do {
+            try context.save()
+            //onSave?(selectedEmoji, title, date, content)
+            presentationMode.wrappedValue.dismiss()
+        } catch {
+            context.rollback()
+            print("Failed to save EmotionRecordEntity:", error)
+        }
     }
 }
 

--- a/HaruDam/HaruDam/Features/Record/View/EmotionRecordWriteView.swift
+++ b/HaruDam/HaruDam/Features/Record/View/EmotionRecordWriteView.swift
@@ -10,36 +10,28 @@ import SwiftUI
 import CoreData
 
 struct EmotionRecordWriteView: View {
-
+    
     @Environment(\.dismiss) private var dismiss
-    @Environment(\.presentationMode) private var presentationMode
     @Environment(\.managedObjectContext) private var context
-
-    @State private var selectedEmoji: String = "😌"
-    @State private var title: String = ""
-    @State private var date: Date = Date()
-    @State private var content: String = ""
-    @State private var tags: [String] = []
-
-    /// 저장 버튼 눌렀을 때 상위에서 처리할 수 있도록 콜백
-    var onSave: ((String, String, Date, String) -> Void)?
-
+    
+    @StateObject private var viewModel = EmotionRecordWriteViewModel()
+    
     private let emojiOptions: [String] = ["😌", "😊", "😢", "😡", "😰", "🤔", "🥰", "🤯"]
-
+    
     var body: some View {
         NavigationStack {
             ZStack {
                 AppColor.background.ignoresSafeArea()
-
+                
                 ScrollView(showsIndicators: false) {
                     VStack(alignment: .leading, spacing: 24) {
-
+                        
                         headerSection
                         emojiSection
                         dateSection
                         titleSection
                         contentSection
-
+                        
                         Spacer()
                     }
                     .padding(.horizontal, 20)
@@ -56,72 +48,71 @@ struct EmotionRecordWriteView: View {
                     }
                     .foregroundColor(AppColor.textSecondary)
                 }
-
+                
                 ToolbarItem(placement: .confirmationAction) {
                     Button("저장") {
-                        handleSave()
+                        Task {
+                            await viewModel.save(context: context)
+                            if viewModel.errorMessage == nil {
+                                dismiss()
+                            }
+                        }
                     }
-                    .foregroundColor(canSave ? AppColor.primary : AppColor.textSecondary)
-                    .disabled(!canSave)
+                    .foregroundColor(viewModel.canSave ? AppColor.primary : AppColor.textSecondary)
+                    .disabled(!viewModel.canSave || viewModel.isSaving)
                 }
             }
         }
     }
-
-    // 저장 가능 여부
-    private var canSave: Bool {
-        !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
-        !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-    }
-
+    
     // MARK: - Sections
     private var headerSection: some View {
         VStack(alignment: .leading, spacing: 4) {
             Text("오늘의 감정을 기록해볼까요?")
                 .font(.system(size: 20, weight: .semibold))
                 .foregroundColor(AppColor.textPrimary)
-
+            
             Text("지금 느끼는 감정과 떠오르는 생각들을 편하게 적어주세요.")
                 .font(.system(size: 13))
                 .foregroundColor(AppColor.textSecondary)
         }
     }
-
+    
     private var emojiSection: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("오늘의 감정")
                 .font(.system(size: 15, weight: .semibold))
                 .foregroundColor(AppColor.textPrimary)
-
+            
             HStack(spacing: 16) {
                 ZStack {
                     Circle()
                         .fill(AppColor.background)
                         .shadow(color: Color.black.opacity(0.05), radius: 8, x: 0, y: 4)
-
-                    Text(selectedEmoji)
+                    
+                    Text(viewModel.emotion)
                         .font(.system(size: 32))
                 }
                 .frame(width: 64, height: 64)
-
+                
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(spacing: 12) {
                         ForEach(emojiOptions, id: \.self) { emoji in
                             Button {
-                                selectedEmoji = emoji
+                                viewModel.emotion = emoji
                             } label: {
                                 Text(emoji)
                                     .font(.system(size: 26))
                                     .padding(10)
                                     .background(
                                         Circle()
-                                            .fill(selectedEmoji == emoji
+                                            .fill(viewModel.emotion == emoji
                                                   ? AppColor.primary.opacity(0.15)
                                                   : Color.white.opacity(0.9))
                                     )
                                     .overlay(
                                         Circle()
-                                            .stroke(selectedEmoji == emoji
+                                            .stroke(viewModel.emotion == emoji
                                                     ? AppColor.primary
                                                     : Color.clear, lineWidth: 1)
                                     )
@@ -133,30 +124,30 @@ struct EmotionRecordWriteView: View {
             }
         }
     }
-
+    
     private var dateSection: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text("날짜")
                 .font(.system(size: 15, weight: .semibold))
                 .foregroundColor(AppColor.textPrimary)
-
+            
             DatePicker(
                 "",
-                selection: $date,
+                selection: $viewModel.date,
                 displayedComponents: .date
             )
             .labelsHidden()
             .tint(AppColor.primary)
         }
     }
-
+    
     private var titleSection: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text("감정 한 줄 제목")
                 .font(.system(size: 15, weight: .semibold))
                 .foregroundColor(AppColor.textPrimary)
-
-            TextField("예: 평온한 하루", text: $title)
+            
+            TextField("예: 평온한 하루", text: $viewModel.title)
                 .font(.system(size: 15))
                 .padding(.horizontal, 14)
                 .padding(.vertical, 10)
@@ -170,24 +161,24 @@ struct EmotionRecordWriteView: View {
                 )
         }
     }
-
+    
     private var contentSection: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text("내용")
                 .font(.system(size: 15, weight: .semibold))
                 .foregroundColor(AppColor.textPrimary)
-
+            
             ZStack(alignment: .topLeading) {
                 RoundedRectangle(cornerRadius: 16)
                     .fill(Color.white.opacity(0.95))
                     .shadow(color: Color.black.opacity(0.02), radius: 6, x: 0, y: 3)
-
-                TextEditor(text: $content)
+                
+                TextEditor(text: $viewModel.content)
                     .font(.system(size: 15))
                     .padding(12)
                     .scrollContentBackground(.hidden)
-
-                if content.isEmpty {
+                
+                if viewModel.content.isEmpty {
                     Text("오늘 있었던 일이나 느낀 점을 자유롭게 적어보세요.")
                         .font(.system(size: 14))
                         .foregroundColor(AppColor.textSecondary)
@@ -197,44 +188,4 @@ struct EmotionRecordWriteView: View {
             .frame(minHeight: 160)
         }
     }
-
-    // MARK: - 저장
-    private func handleSave() {
-        guard canSave else { return }
-
-        // CoreData(NSManagedObject) 엔티티에 저장
-        let newRecord = EmotionRecordEntity(context: context)
-        newRecord.id = UUID()
-        newRecord.title = title
-        newRecord.emotion = selectedEmoji
-        newRecord.content = content
-        newRecord.createdAt = date
-        newRecord.updatedAt = Date()
-
-        // Supabase 동기화용
-        newRecord.syncStatus = "pending"
-        newRecord.serverId = nil
-
-        let tagsJson: String
-        do {
-            let data = try JSONEncoder().encode(tags)
-            tagsJson = String(data: data, encoding: .utf8) ?? "[]"
-        } catch {
-            tagsJson = "[]"
-        }
-        newRecord.tags = tagsJson
-
-        do {
-            try context.save()
-            //onSave?(selectedEmoji, title, date, content)
-            presentationMode.wrappedValue.dismiss()
-        } catch {
-            context.rollback()
-            print("Failed to save EmotionRecordEntity:", error)
-        }
-    }
-}
-
-#Preview {
-    EmotionRecordWriteView()
 }

--- a/HaruDam/HaruDam/Features/Record/View/RecordView.swift
+++ b/HaruDam/HaruDam/Features/Record/View/RecordView.swift
@@ -118,7 +118,7 @@ struct RecordView: View {
         VStack(spacing: 14) {
             ForEach(records) { record in
                 NavigationLink {
-                    EmotionRecordDetailView()
+                    EmotionRecordDetailView(record: record)
                 } label: {
                     EmotionRecordRow(record: record)
                 }

--- a/HaruDam/HaruDam/Features/Record/View/RecordView.swift
+++ b/HaruDam/HaruDam/Features/Record/View/RecordView.swift
@@ -7,14 +7,30 @@
 //
 
 import SwiftUI
+import CoreData
 
 // MARK: - View
 struct RecordView: View {
 
-    // 나중에 SwiftData / ViewModel 연결하면 여기로 교체
-    private let records: [EmotionRecord] = EmotionRecord.mockData
-    // TODO: ViewModel에서 이번 달 기록 일수 주입 예정
-    private let monthlyRecordedDays: Int = 24
+    @FetchRequest(
+        sortDescriptors: [NSSortDescriptor(keyPath: \EmotionRecordEntity.createdAt, ascending: false)],
+        animation: .default
+    )
+    private var records: FetchedResults<EmotionRecordEntity>
+
+    private var monthlyRecordedDays: Int {
+        let calendar = Calendar.current
+        let now = Date()
+        guard let monthInterval = calendar.dateInterval(of: .month, for: now) else { return 0 }
+
+        // 이번 달에 기록된 날짜(일) 단위로 중복 제거
+        let days = records
+            .compactMap { $0.createdAt }
+            .filter { monthInterval.contains($0) }
+            .map { calendar.startOfDay(for: $0) }
+
+        return Set(days).count
+    }
 
     var body: some View {
         NavigationStack {
@@ -102,7 +118,7 @@ struct RecordView: View {
         VStack(spacing: 14) {
             ForEach(records) { record in
                 NavigationLink {
-                    EmotionRecordDetailView(record: record)
+                    EmotionRecordDetailView()
                 } label: {
                     EmotionRecordRow(record: record)
                 }
@@ -116,10 +132,10 @@ struct RecordView: View {
 
 struct EmotionRecordRow: View {
 
-    let record: EmotionRecord
+    let record: EmotionRecordEntity
     private var formatter: DateFormatter = .init()
     
-    init(record: EmotionRecord) {
+    init(record: EmotionRecordEntity) {
             self.record = record
             formatter.locale = Locale(identifier: "ko_KR")
             formatter.dateFormat = "yyyy년 M월 d일 · EEEE"
@@ -132,21 +148,21 @@ struct EmotionRecordRow: View {
                     .fill(AppColor.background)
                     .shadow(color: Color.black.opacity(0.03), radius: 8, x: 0, y: 4)
 
-                Text(record.emoji)
+                Text(record.emotion ?? "🙂")
                     .font(.system(size: 28))
             }
             .frame(width: 56, height: 56)
 
             VStack(alignment: .leading, spacing: 6) {
-                Text(record.title)
+                Text(record.title ?? "")
                     .font(.system(size: 16, weight: .semibold))
                     .foregroundColor(AppColor.textPrimary)
 
-                Text(formatter.string(from: record.date))
+                Text(formatter.string(from: record.createdAt ?? Date()))
                     .font(.system(size: 12))
                     .foregroundColor(AppColor.textSecondary)
 
-                Text(record.description)
+                Text(record.content ?? "")
                     .font(.system(size: 13))
                     .foregroundColor(AppColor.textSecondary)
                     .lineLimit(2)

--- a/HaruDam/HaruDam/Features/Record/ViewModel/EmotionRecordEditViewModel.swift
+++ b/HaruDam/HaruDam/Features/Record/ViewModel/EmotionRecordEditViewModel.swift
@@ -1,0 +1,135 @@
+//
+//  EmotionRecordEditViewModel.swift
+//  HaruDam
+//
+//  Created by 존진 on 1/20/26.
+//  Copyright © 2026 kr.co.HaruDam. All rights reserved.
+//
+
+import Foundation
+import CoreData
+
+// MARK: - SyncStatus
+enum SyncStatus: String {
+    case pending
+    case synced
+    case failed
+}
+
+@MainActor
+final class EmotionRecordEditViewModel: ObservableObject {
+    @Published var emotion: String
+    @Published var title: String
+    @Published var content: String
+    @Published var tags: [String]
+    
+    // UI 상태
+    @Published var isSyncing: Bool = false
+    @Published var errorMessage: String? = nil
+    
+    private let record: EmotionRecordEntity
+    
+    init(record: EmotionRecordEntity) {
+        self.record = record
+        self.emotion = record.emotion ?? "🙂"
+        self.title = record.title ?? ""
+        self.content = record.content ?? ""
+        self.tags = Self.decodeTagsJson(record.tags)
+    }
+    
+    var canSave: Bool {
+        !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+    
+    // MARK: - Update
+    func save(context: NSManagedObjectContext) async {
+        guard canSave else { return }
+        isSyncing = true
+        errorMessage = nil
+        
+        record.emotion = emotion
+        record.title = title
+        record.content = content
+        record.updatedAt = Date()
+        record.syncStatus = SyncStatus.pending.rawValue
+        record.tags = Self.encodeTagsJson(tags)
+        
+        do {
+            try context.save()
+        } catch {
+            context.rollback()
+            errorMessage = "로컬 수정에 실패했어요."
+            isSyncing = false
+            return
+        }
+        
+        // 서버 update (serverId 없으면 서버에 아직 없음 → pending 유지)
+        guard record.serverId != nil else {
+            isSyncing = false
+            return
+        }
+        
+        do {
+            try await EmotionRecordService.shared.update(record: record)
+            record.syncStatus = SyncStatus.synced.rawValue
+            record.updatedAt = Date()
+            try context.save()
+        } catch {
+            record.syncStatus = SyncStatus.failed.rawValue
+            try? context.save()
+            errorMessage = "서버 동기화(수정)에 실패했어요."
+        }
+        
+        isSyncing = false
+    }
+    
+    // MARK: - Delete
+    func delete(context: NSManagedObjectContext) async {
+        isSyncing = true
+        errorMessage = nil
+        
+        // delete 전에 serverId 캡처
+        let serverId = record.serverId
+        
+        // 로컬 삭제
+        context.delete(record)
+        do {
+            try context.save()
+        } catch {
+            context.rollback()
+            errorMessage = "로컬 삭제에 실패했어요."
+            isSyncing = false
+            return
+        }
+        
+        // 서버 삭제 (serverId 없으면 종료)
+        guard let serverId, !serverId.isEmpty else {
+            isSyncing = false
+            return
+        }
+        
+        do {
+            try await EmotionRecordService.shared.delete(recordId: serverId)
+        } catch {
+            errorMessage = "서버 동기화(삭제)에 실패했어요."
+        }
+        
+        isSyncing = false
+    }
+    
+    // MARK: - Tags(JSON)
+    private static func encodeTagsJson(_ tags: [String]) -> String {
+        do {
+            let data = try JSONEncoder().encode(tags)
+            return String(data: data, encoding: .utf8) ?? "[]"
+        } catch {
+            return "[]"
+        }
+    }
+    
+    private static func decodeTagsJson(_ json: String?) -> [String] {
+        guard let json, let data = json.data(using: .utf8) else { return [] }
+        return (try? JSONDecoder().decode([String].self, from: data)) ?? []
+    }
+}

--- a/HaruDam/HaruDam/Features/Record/ViewModel/EmotionRecordWriteViewModel.swift
+++ b/HaruDam/HaruDam/Features/Record/ViewModel/EmotionRecordWriteViewModel.swift
@@ -14,7 +14,6 @@ final class EmotionRecordWriteViewModel: ObservableObject {
     @Published var emotion: String = "☺️"
     @Published var title: String = ""
     @Published var content: String = ""
-    @Published var date: Date = Date()
     @Published var tags: [String] = []
     
     // UI 상태
@@ -22,7 +21,8 @@ final class EmotionRecordWriteViewModel: ObservableObject {
     @Published var errorMessage: String? = nil
     
     var canSave: Bool {
-        !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
     
     func save(context: NSManagedObjectContext) async {
@@ -35,7 +35,7 @@ final class EmotionRecordWriteViewModel: ObservableObject {
         record.emotion = emotion
         record.title = title
         record.content = content
-        record.createdAt = date
+        record.createdAt = Date()
         record.updatedAt = Date()
         record.serverId = nil
         record.syncStatus = SyncStatus.pending.rawValue

--- a/HaruDam/HaruDam/Features/Record/ViewModel/EmotionRecordWriteViewModel.swift
+++ b/HaruDam/HaruDam/Features/Record/ViewModel/EmotionRecordWriteViewModel.swift
@@ -1,0 +1,78 @@
+//
+//  EmotionRecordWriteViewModel.swift
+//  HaruDam
+//
+//  Created by 존진 on 1/20/26.
+//  Copyright © 2026 kr.co.HaruDam. All rights reserved.
+//
+
+import Foundation
+import CoreData
+
+@MainActor
+final class EmotionRecordWriteViewModel: ObservableObject {
+    @Published var emotion: String = "☺️"
+    @Published var title: String = ""
+    @Published var content: String = ""
+    @Published var date: Date = Date()
+    @Published var tags: [String] = []
+    
+    // UI 상태
+    @Published var isSaving: Bool = false
+    @Published var errorMessage: String? = nil
+    
+    var canSave: Bool {
+        !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+    
+    func save(context: NSManagedObjectContext) async {
+        guard canSave else { return }
+        isSaving = true
+        errorMessage = nil
+        
+        let record = EmotionRecordEntity(context: context)
+        record.id = UUID()
+        record.emotion = emotion
+        record.title = title
+        record.content = content
+        record.createdAt = date
+        record.updatedAt = Date()
+        record.serverId = nil
+        record.syncStatus = SyncStatus.pending.rawValue
+        
+        record.tags = encodeTagsJson(tags)
+        
+        do {
+            try context.save()
+        } catch {
+            context.rollback()
+            errorMessage = "로컬 저장에 실패했습니다. (\(error.localizedDescription))"
+            isSaving = false
+            return
+        }
+        
+        do {
+            let serverId = try await EmotionRecordService.shared.insert(record: record)
+            record.serverId = serverId
+            record.syncStatus = SyncStatus.synced.rawValue
+            record.updatedAt = Date()
+            try context.save()
+        } catch {
+            record.syncStatus = SyncStatus.failed.rawValue
+            try? context.save()
+            errorMessage = "서버 동기화에 실패했습니다. (\(error.localizedDescription))"
+        }
+        
+        isSaving = false
+        
+    }
+    
+    private func encodeTagsJson(_ tags: [String]) -> String {
+        do {
+            let data = try JSONEncoder().encode(tags)
+            return String(data: data, encoding: .utf8) ?? "[]"
+        } catch {
+            return "[]"
+        }
+    }
+}

--- a/HaruDam/HaruDam/Services/EmotionRecordService.swift
+++ b/HaruDam/HaruDam/Services/EmotionRecordService.swift
@@ -1,0 +1,124 @@
+//
+//  EmotionRecordService.swift
+//  HaruDam
+//
+//  Created by 존진 on 1/20/26.
+//  Copyright © 2026 kr.co.HaruDam. All rights reserved.
+//
+
+import Foundation
+import Supabase
+import CoreData
+
+final class EmotionRecordService {
+    static let shared = EmotionRecordService()
+    private let supabase: SupabaseManager
+
+    init(supabase: SupabaseManager = .shared) {
+        self.supabase = supabase
+    }
+
+    private struct InsertResponse: Decodable {
+        let id: String
+    }
+
+    // MARK: - DTO
+    private struct EmotionRecordInsertDTO: Encodable {
+        let user_id: String
+        let emotion: String
+        let title: String
+        let content: String
+        let tags: [String]
+        let created_at: String
+        let updated_at: String
+    }
+
+    private struct EmotionRecordUpdateDTO: Encodable {
+        let emotion: String
+        let title: String
+        let content: String
+        let tags: [String]
+        let updated_at: String
+    }
+
+    private func decodeTagsJson(_ json: String?) -> [String] {
+        guard let json, let data = json.data(using: .utf8) else { return [] }
+        return (try? JSONDecoder().decode([String].self, from: data)) ?? []
+    }
+
+    private let isoFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    /// Supabase - insert 생성된 서버 id(uuid)를 반환
+    /// - Note: 테이블명은 `emotion_records`사용
+    func insert(record: EmotionRecordEntity) async throws -> String {
+        // Supabase Auth 세션에서 user_id 가져오기
+        let session = try await supabase.client.auth.session
+        let userId = session.user.id.uuidString
+
+        let tagsArray = decodeTagsJson(record.tags)
+
+        let payload = EmotionRecordInsertDTO(
+            user_id: userId,
+            emotion: record.emotion ?? "",
+            title: record.title ?? "",
+            content: record.content ?? "",
+            tags: tagsArray,
+            created_at: isoFormatter.string(from: record.createdAt ?? Date()),
+            updated_at: isoFormatter.string(from: record.updatedAt ?? Date())
+        )
+
+        let inserted: [InsertResponse] = try await supabase.client
+            .from("emotion_records")
+            .insert(payload)
+            .select("id")
+            .execute()
+            .value
+
+        guard let serverId = inserted.first?.id else {
+            throw NSError(domain: "EmotionRecordService", code: -1, userInfo: [NSLocalizedDescriptionKey: "Insert 응답에서 id를 받지 못했습니다."])
+        }
+
+        return serverId
+    }
+
+    /// Supabase - update  (record.serverId 필요)
+    func update(record: EmotionRecordEntity) async throws {
+        guard let serverId = record.serverId, !serverId.isEmpty else { return }
+
+        let tagsArray = decodeTagsJson(record.tags)
+
+        let payload = EmotionRecordUpdateDTO(
+            emotion: record.emotion ?? "",
+            title: record.title ?? "",
+            content: record.content ?? "",
+            tags: tagsArray,
+            updated_at: isoFormatter.string(from: record.updatedAt ?? Date())
+        )
+
+        _ = try await supabase.client
+            .from("emotion_records")
+            .update(payload)
+            .eq("id", value: serverId)
+            .execute()
+    }
+
+    /// Supabase - delete
+    func delete(recordId: String) async throws {
+        guard !recordId.isEmpty else { return }
+
+        _ = try await supabase.client
+            .from("emotion_records")
+            .delete()
+            .eq("id", value: recordId)
+            .execute()
+    }
+
+    func delete(record: EmotionRecordEntity) async throws {
+        guard let serverId = record.serverId, !serverId.isEmpty else { return }
+        try await delete(recordId: serverId)
+    }
+}

--- a/HaruDam/HaruDam/Utils/SupabaseManager.swift
+++ b/HaruDam/HaruDam/Utils/SupabaseManager.swift
@@ -28,7 +28,15 @@ final class SupabaseManager {
 
         self.supabaseURL = url
         self.supabaseKey = key
-        self.client = SupabaseClient(supabaseURL: url, supabaseKey: key)
+        self.client = SupabaseClient(
+            supabaseURL: url,
+            supabaseKey: key,
+            options: SupabaseClientOptions(
+                auth: .init(
+                    emitLocalSessionAsInitialSession: true
+                )
+            )
+        )
     }
     
     // MARK: - Auth Redirect


### PR DESCRIPTION
## 🧩작업 내용
- 감정 기록 CoreData 모델 설계
    - EmotionRecordEntity 추가(감정, 제목, 내용, 생성/수정일 추가)
    - 서버 동기화를 위한 serverId, syncStatus 필드 포함
- 감정 기록 작성 기능
    - CoreData 저장, Supabase insert 연동 
    - **당일 감정 기록으로 캘린더 제거** 
- 감정 기록 리스트 및 상세 조회
    - 기록 리스트에서 선택 시 단일 기록 상제 조회
    - EmotionRecordDetailView -> 감정 기록 수정/삭제 가능
- 감정 기록 수정/삭제
    - 수정/삭제 로직 ViewModel 분리
- Supabase 연동
    - insert/update/delete 구현


## 🚧 추후 작업할 내용 (미완성 부분)
<!-- 이슈 번호와 함께 향후 작업 예정인 내용을 작성해주세요 -->
<!-- 연결된 이슈가 있다면 작성해주세요 (예: #123) -->
<!-- 체크리스트 작성 (예: - [ ]) -->
- 당일 감정 기록한 경우 작성 제한 처리 예정
- 감정 기록 태그 기능

## 📷 스크린샷
<!-- UI 변경이 있는 경우 변경 전/후 스크린샷을 첨부해주세요 -->
<table>
  <tr>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/361ecbb2-739c-46cd-9543-676a05575fbf" width="200"/><br>
      <p>작성 화면</p>
    </td>
<td align="center">
      <img src="https://github.com/user-attachments/assets/0e26e6e8-9665-46ef-ad01-128ffbbf499c" width="200"/><br>
      <p>수정 화면</p>
    </td>
<td align="center">
      <img src="https://github.com/user-attachments/assets/4fdf0772-a7ea-47e4-81b5-28671f6eff51" width="200"/><br>
      <p>삭제 시</p>
    </td>
  </tr>
</table>

## 🗒️ 기타 참고 사항
<!-- 리뷰어가 참고하면 좋을 추가 정보 -->
- 감정 기록은 당일 기준 기록만 가능하도록 하였습니다.
- 서버(Supabase) 저장 실패에도 로컬 기록은 유지됩니다.
