### PR TITLE
[feature/home-dashboard]: 홈 화면 주간 감정 요약 및 최근 감정 섹션 구현

### DIFF
--- a/HaruDam/HaruDam.xcodeproj/project.pbxproj
+++ b/HaruDam/HaruDam.xcodeproj/project.pbxproj
@@ -107,6 +107,8 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		8C7D61D52F23410D007349CE /* ViewModel */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = ViewModel; sourceTree = "<group>"; };
+		8C7D61D62F23413A007349CE /* Model */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Model; sourceTree = "<group>"; };
 		8CA9213E2ED87CAD00E4852B /* Sections */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Sections; sourceTree = "<group>"; };
 		8CA9214D2ED993D600E4852B /* Record */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Record; sourceTree = "<group>"; };
 		8CA9214F2ED993EA00E4852B /* Profile */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Profile; sourceTree = "<group>"; };
@@ -278,7 +280,9 @@
 		BD0FFFD04D9C9AE769F30E88 /* Home */ = {
 			isa = PBXGroup;
 			children = (
+				8C7D61D62F23413A007349CE /* Model */,
 				ED413DC81DC53E4028194922 /* View */,
+				8C7D61D52F23410D007349CE /* ViewModel */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -393,6 +397,8 @@
 			dependencies = (
 			);
 			fileSystemSynchronizedGroups = (
+				8C7D61D52F23410D007349CE /* ViewModel */,
+				8C7D61D62F23413A007349CE /* Model */,
 				8CA9213E2ED87CAD00E4852B /* Sections */,
 				8CA9214D2ED993D600E4852B /* Record */,
 				8CA9214F2ED993EA00E4852B /* Profile */,

--- a/HaruDam/HaruDam.xcodeproj/project.pbxproj
+++ b/HaruDam/HaruDam.xcodeproj/project.pbxproj
@@ -109,6 +109,7 @@
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		8C7D61D52F23410D007349CE /* ViewModel */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = ViewModel; sourceTree = "<group>"; };
 		8C7D61D62F23413A007349CE /* Model */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Model; sourceTree = "<group>"; };
+		8C7D61DB2F24E1FB007349CE /* Repository */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Repository; sourceTree = "<group>"; };
 		8CA9213E2ED87CAD00E4852B /* Sections */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Sections; sourceTree = "<group>"; };
 		8CA9214D2ED993D600E4852B /* Record */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Record; sourceTree = "<group>"; };
 		8CA9214F2ED993EA00E4852B /* Profile */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Profile; sourceTree = "<group>"; };
@@ -311,6 +312,7 @@
 		CF9730CA0643A7DF2336B557 /* HaruDam */ = {
 			isa = PBXGroup;
 			children = (
+				8C7D61DB2F24E1FB007349CE /* Repository */,
 				8CA921932EEAFBEC00E4852B /* Shared */,
 				8CE3F7E89F3EB36430039FFE /* Components */,
 				F06AF7C47EBE114236F0DA7E /* Config */,
@@ -399,6 +401,7 @@
 			fileSystemSynchronizedGroups = (
 				8C7D61D52F23410D007349CE /* ViewModel */,
 				8C7D61D62F23413A007349CE /* Model */,
+				8C7D61DB2F24E1FB007349CE /* Repository */,
 				8CA9213E2ED87CAD00E4852B /* Sections */,
 				8CA9214D2ED993D600E4852B /* Record */,
 				8CA9214F2ED993EA00E4852B /* Profile */,

--- a/HaruDam/HaruDam/Features/Home/Model/WeeklyEmotionSummary.swift
+++ b/HaruDam/HaruDam/Features/Home/Model/WeeklyEmotionSummary.swift
@@ -1,0 +1,16 @@
+//
+//  WeeklyEmotionSummary.swift
+//  HaruDam
+//
+//  Created by 존진 on 1/23/26.
+//  Copyright © 2026 kr.co.HaruDam. All rights reserved.
+//
+
+import Foundation
+
+struct WeeklyEmotionSummary: Equatable {
+    let emoji: String
+    let title: String
+    let description: String
+    let recordedDays: Int
+}

--- a/HaruDam/HaruDam/Features/Home/View/HomeView.swift
+++ b/HaruDam/HaruDam/Features/Home/View/HomeView.swift
@@ -13,7 +13,10 @@ struct HomeView: View {
     
     // TODO: 추후 ViewModel에서 관리
     private let recentEmotions: [EmotionRecord] = EmotionRecord.mockData
-    private let weeklyEmotions: [CGFloat] = WeeklyEmotionChartView.mockValues
+
+    @StateObject private var weeklySummaryVM = WeeklyEmotionSummaryViewModel(
+        repository: EmotionRecordService.shared
+    )
     
     // MARK: - Body
     
@@ -24,6 +27,9 @@ struct HomeView: View {
         }
         .sheet(isPresented: $isPresentingWriteView) {
             EmotionRecordWriteView()
+        }
+        .task {
+            await weeklySummaryVM.loadThisWeekSummary()
         }
     }
     
@@ -43,7 +49,7 @@ struct HomeView: View {
             VStack(alignment: .leading, spacing: 24) {
                 HeaderSection()
                 TodayEmotionCardView(onTap: handleTodayEmotionTap)
-                WeeklyFlowSection(values: weeklyEmotions)
+                WeeklySummarySection(viewModel: weeklySummaryVM)
                 RecentEmotionSection(emotions: recentEmotions)
             }
             .padding(.horizontal, 24)
@@ -85,24 +91,97 @@ struct HeaderSection: View {
     }
 }
 
-// MARK: - Weekly Flow Section
+// MARK: - Weekly Summary Section
 
-struct WeeklyFlowSection: View {
-    let values: [CGFloat]
-    
+struct WeeklySummarySection: View {
+
+    @ObservedObject var viewModel: WeeklyEmotionSummaryViewModel
+
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text("이번 주 감정의 흐름")
+            Text("이번 주 감정 요약")
                 .font(.system(size: 15, weight: .semibold))
-            
-            WeeklyEmotionChartView(values: values)
-                .frame(height: 160)
-                .frame(maxWidth: .infinity)
-                .background(chartBackground)
+
+            WeeklyEmotionSummaryCard(state: viewModel.state, summary: viewModel.summary)
         }
     }
-    
-    private var chartBackground: some View {
+}
+
+struct WeeklyEmotionSummaryCard: View {
+
+    let state: WeeklyEmotionSummaryViewModel.State
+    let summary: WeeklyEmotionSummary?
+
+    var body: some View {
+        content
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(18)
+            .background(cardBackground)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch state {
+        case .idle, .loading:
+            HStack(spacing: 12) {
+                ProgressView()
+                Text("이번 주 감정을 불러오는 중…")
+                    .font(.system(size: 14))
+                    .foregroundColor(.gray)
+            }
+
+        case .empty:
+            VStack(alignment: .leading, spacing: 6) {
+                Text("이번 주 기록이 아직 없어요")
+                    .font(.system(size: 15, weight: .semibold))
+                Text("오늘의 감정을 먼저 담아볼까요?")
+                    .font(.system(size: 13))
+                    .foregroundColor(.gray)
+            }
+
+        case .failed(let message):
+            VStack(alignment: .leading, spacing: 6) {
+                Text("요약을 불러오지 못했어요")
+                    .font(.system(size: 15, weight: .semibold))
+                Text(message)
+                    .font(.system(size: 12))
+                    .foregroundColor(.gray)
+                    .lineLimit(2)
+            }
+
+        case .loaded:
+            if let summary {
+                HStack(alignment: .top, spacing: 12) {
+                    Text(summary.emoji)
+                        .font(.system(size: 38))
+
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(summary.title)
+                            .font(.system(size: 16, weight: .semibold))
+
+                        Text(summary.description)
+                            .font(.system(size: 13))
+                            .foregroundColor(.gray)
+                            .lineLimit(2)
+
+                        Text("기록한 날: \(summary.recordedDays)일")
+                            .font(.system(size: 12))
+                            .foregroundColor(.gray)
+                            .padding(.top, 2)
+                    }
+
+                    Spacer(minLength: 0)
+                }
+            } else {
+                // loaded인데 summary가 없는 경우는 방어 처리
+                Text("요약 정보가 없어요")
+                    .font(.system(size: 14))
+                    .foregroundColor(.gray)
+            }
+        }
+    }
+
+    private var cardBackground: some View {
         RoundedRectangle(cornerRadius: 24, style: .continuous)
             .fill(Color.white.opacity(0.95))
             .shadow(

--- a/HaruDam/HaruDam/Features/Home/View/HomeView.swift
+++ b/HaruDam/HaruDam/Features/Home/View/HomeView.swift
@@ -8,18 +8,18 @@
 import SwiftUI
 
 struct HomeView: View {
-    
     @State private var isPresentingWriteView = false
-    
-    // TODO: 추후 ViewModel에서 관리
-    private let recentEmotions: [EmotionRecord] = EmotionRecord.mockData
 
     @StateObject private var weeklySummaryVM = WeeklyEmotionSummaryViewModel(
         repository: EmotionRecordService.shared
     )
-    
+
+    @StateObject private var recentEmotionVM = RecentEmotionListViewModel(
+        repository: EmotionRecordService.shared
+    )
+
     // MARK: - Body
-    
+
     var body: some View {
         ZStack {
             backgroundGradient
@@ -28,13 +28,24 @@ struct HomeView: View {
         .sheet(isPresented: $isPresentingWriteView) {
             EmotionRecordWriteView()
         }
+        .onChange(of: isPresentingWriteView) { isPresented in
+            // 작성 화면이 닫히는 순간(저장 후 dismiss) 홈 데이터를 즉시 갱신
+            guard isPresented == false else { return }
+            Task {
+                async let weekly: Void = weeklySummaryVM.loadThisWeekSummary()
+                async let recent: Void = recentEmotionVM.loadRecent()
+                _ = await (weekly, recent)
+            }
+        }
         .task {
-            await weeklySummaryVM.loadThisWeekSummary()
+            async let weekly: Void = weeklySummaryVM.loadThisWeekSummary()
+            async let recent: Void = recentEmotionVM.loadRecent()
+            _ = await (weekly, recent)
         }
     }
-    
+
     // MARK: - UI Components
-    
+
     private var backgroundGradient: some View {
         LinearGradient(
             colors: [AppColor.background],
@@ -43,23 +54,23 @@ struct HomeView: View {
         )
         .ignoresSafeArea()
     }
-    
+
     private var scrollContent: some View {
         ScrollView(showsIndicators: false) {
             VStack(alignment: .leading, spacing: 24) {
                 HeaderSection()
                 TodayEmotionCardView(onTap: handleTodayEmotionTap)
                 WeeklySummarySection(viewModel: weeklySummaryVM)
-                RecentEmotionSection(emotions: recentEmotions)
+                RecentEmotionSection(viewModel: recentEmotionVM)
             }
             .padding(.horizontal, 24)
             .padding(.top, 32)
             .padding(.bottom, 16)
         }
     }
-    
+
     // MARK: - Actions
-    
+
     private func handleTodayEmotionTap() {
         isPresentingWriteView = true
     }
@@ -68,21 +79,21 @@ struct HomeView: View {
 // MARK: - Header Section
 
 struct HeaderSection: View {
-    
+
     @EnvironmentObject private var authStore: AuthStore
-    
+
     private var formattedToday: String {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "ko_KR")
         formatter.dateFormat = "yyyy년 M월 d일 EEEE"
         return formatter.string(from: Date())
     }
-    
+
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text("안녕하세요 \(authStore.displayUserName)님")
                 .font(.system(size: 28, weight: .bold))
-            
+
             Text(formattedToday)
                 .font(.system(size: 13))
                 .foregroundColor(.gray)
@@ -173,7 +184,6 @@ struct WeeklyEmotionSummaryCard: View {
                     Spacer(minLength: 0)
                 }
             } else {
-                // loaded인데 summary가 없는 경우는 방어 처리
                 Text("요약 정보가 없어요")
                     .font(.system(size: 14))
                     .foregroundColor(.gray)
@@ -196,20 +206,192 @@ struct WeeklyEmotionSummaryCard: View {
 // MARK: - Recent Emotion Section
 
 struct RecentEmotionSection: View {
-    let emotions: [EmotionRecord]
-    
+
+    @ObservedObject var viewModel: RecentEmotionListViewModel
+
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("최근 담은 감정")
                 .font(.system(size: 15, weight: .semibold))
-            
+
+            content
+        }
+        .padding(.bottom, 16)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch viewModel.state {
+        case .idle, .loading:
+            HStack(spacing: 12) {
+                ProgressView()
+                Text("최근 기록을 불러오는 중…")
+                    .font(.system(size: 14))
+                    .foregroundColor(.gray)
+            }
+
+        case .empty:
+            VStack(alignment: .leading, spacing: 6) {
+                Text("최근 기록이 없어요")
+                    .font(.system(size: 15, weight: .semibold))
+                Text("오늘의 감정을 먼저 담아볼까요?")
+                    .font(.system(size: 13))
+                    .foregroundColor(.gray)
+            }
+
+        case .failed(let message):
+            VStack(alignment: .leading, spacing: 6) {
+                Text("최근 기록을 불러오지 못했어요")
+                    .font(.system(size: 15, weight: .semibold))
+                Text(message)
+                    .font(.system(size: 12))
+                    .foregroundColor(.gray)
+                    .lineLimit(2)
+            }
+
+        case .loaded:
             VStack(spacing: 10) {
-                ForEach(emotions) { emotion in
-                    RecentEmotionRowView(emotion: emotion)
+                ForEach(viewModel.items) { item in
+                    RecentEmotionRow(item: item)
                 }
             }
         }
-        .padding(.bottom, 16)
+    }
+}
+
+struct RecentEmotionRow: View {
+
+    let item: RecentEmotionItem
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Text(item.emoji)
+                .font(.system(size: 28))
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(item.title.isEmpty ? "(제목 없음)" : item.title)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundColor(.primary)
+                    .lineLimit(1)
+
+                if item.content.isEmpty == false {
+                    Text(item.content)
+                        .font(.system(size: 13))
+                        .foregroundColor(.gray)
+                        .lineLimit(2)
+                }
+
+                Text(item.dateText)
+                    .font(.system(size: 12))
+                    .foregroundColor(.gray)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(14)
+        .background(rowBackground)
+    }
+
+    private var rowBackground: some View {
+        RoundedRectangle(cornerRadius: 18, style: .continuous)
+            .fill(Color.white.opacity(0.95))
+            .shadow(
+                color: Color.black.opacity(0.03),
+                radius: 12,
+                x: 0,
+                y: 6
+            )
+    }
+}
+
+// MARK: - Recent Emotion ViewModel
+
+@MainActor
+final class RecentEmotionListViewModel: ObservableObject {
+
+    enum State: Equatable {
+        case idle
+        case loading
+        case loaded
+        case empty
+        case failed(String)
+    }
+
+    @Published private(set) var state: State = .idle
+    @Published private(set) var items: [RecentEmotionItem] = []
+
+    private let repository: EmotionRecordRepository
+    private let calendar: Calendar
+    private let isoFormatter: ISO8601DateFormatter
+
+    init(repository: EmotionRecordRepository, calendar: Calendar = .current) {
+        self.repository = repository
+        self.calendar = calendar
+
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        self.isoFormatter = f
+    }
+
+    /// 최근 N개 기록을 로드 (기본 5개)
+    /// - Note: 서버에서 최신순 + limit 적용해서 내려받아 클라이언트 가공 비용/대기 시간을 줄인다.
+    func loadRecent(limit: Int = 5) async {
+        state = .loading
+
+        do {
+            let rows = try await repository.fetchRecentRemoteRecords(limit: limit)
+
+            let mapped = rows.compactMap { row -> RecentEmotionItem? in
+                guard
+                    let createdAtString = row.created_at,
+                    let createdAt = isoFormatter.date(from: createdAtString)
+                else { return nil }
+
+                return RecentEmotionItem(
+                    id: row.id,
+                    emoji: normalizeEmoji(row.emotion),
+                    title: row.title ?? "",
+                    content: row.content ?? "",
+                    createdAt: createdAt
+                )
+            }
+
+            // 이미 최신순으로 내려오지만, created_at 파싱 실패/예외를 대비해 한 번 더 정렬
+            items = mapped.sorted { $0.createdAt > $1.createdAt }
+            state = items.isEmpty ? .empty : .loaded
+        } catch {
+            state = .failed(error.localizedDescription)
+        }
+    }
+
+    /// 서버 emotion 값은 "😌, 😊, 😢, 😡, 😰, 🤔, 🥰, 🤯" 이모지로 온다고 가정
+    /// 예외 값은 기본 🤔 처리
+    private func normalizeEmoji(_ emotion: String?) -> String {
+        guard let e = emotion?.trimmingCharacters(in: .whitespacesAndNewlines), e.isEmpty == false else {
+            return "🤔"
+        }
+
+        switch e {
+        case "😌", "😊", "😢", "😡", "😰", "🤔", "🥰", "🤯":
+            return e
+        default:
+            return "🤔"
+        }
+    }
+}
+
+struct RecentEmotionItem: Identifiable, Equatable {
+    let id: String
+    let emoji: String
+    let title: String
+    let content: String
+    let createdAt: Date
+
+    var dateText: String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "M/d E"
+        return formatter.string(from: createdAt)
     }
 }
 

--- a/HaruDam/HaruDam/Features/Home/ViewModel/WeeklyEmotionSummaryViewModel.swift
+++ b/HaruDam/HaruDam/Features/Home/ViewModel/WeeklyEmotionSummaryViewModel.swift
@@ -1,0 +1,182 @@
+//
+//  WeeklyEmotionSummaryViewModel.swift
+//  HaruDam
+//
+//  Created by 존진 on 1/24/26.
+//  Copyright © 2026 kr.co.HaruDam. All rights reserved.
+//
+
+import Foundation
+
+@MainActor
+final class WeeklyEmotionSummaryViewModel: ObservableObject {
+
+    enum State: Equatable {
+        case idle
+        case loading
+        case loaded
+        case empty
+        case failed(String)
+    }
+
+    @Published private(set) var state: State = .idle
+    @Published private(set) var summary: WeeklyEmotionSummary?
+
+    private let repository: EmotionRecordRepository
+    private let calendar: Calendar
+    private let isoFormatter: ISO8601DateFormatter
+
+    init(repository: EmotionRecordRepository, calendar: Calendar = .current) {
+        self.repository = repository
+        self.calendar = calendar
+
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        self.isoFormatter = f
+    }
+
+    /// 홈 화면 진입 시 호출
+    func loadThisWeekSummary() async {
+        state = .loading
+
+        do {
+            let (start, end) = makeThisWeekRange()
+            let rows = try await repository.fetchRemoteRecords(from: start, to: end)
+
+            guard rows.isEmpty == false else {
+                summary = nil
+                state = .empty
+                return
+            }
+
+            summary = buildSummary(from: rows, start: start, end: end)
+            state = .loaded
+        } catch {
+            state = .failed(error.localizedDescription)
+        }
+    }
+}
+
+// MARK: - Summary Builder
+
+@MainActor
+private extension WeeklyEmotionSummaryViewModel {
+
+    // 이번 주(월~일) 날짜 범위
+    func makeThisWeekRange() -> (Date, Date) {
+        var cal = calendar
+        cal.firstWeekday = 2 // 월요일 시작
+
+        let today = cal.startOfDay(for: Date())
+        let weekday = cal.component(.weekday, from: today)
+        let diff = (weekday - cal.firstWeekday + 7) % 7
+
+        let startOfWeek = cal.date(byAdding: .day, value: -diff, to: today)!
+        let endExclusive = cal.date(byAdding: .day, value: 7, to: startOfWeek)!
+
+        return (startOfWeek, endExclusive)
+    }
+
+    func buildSummary(from rows: [RemoteEmotionRecord], start: Date, end: Date) -> WeeklyEmotionSummary {
+        // 날짜별 마지막 감정(가장 최신 created_at) 1개만 반영해서 기록 일수/대표 감정을 안정적으로 계산
+        var latestByDay: [Date: (score: Int, createdAt: Date)] = [:]
+
+        for row in rows {
+            guard
+                let createdAtString = row.created_at,
+                let createdAt = isoFormatter.date(from: createdAtString)
+            else { continue }
+
+            let day = calendar.startOfDay(for: createdAt)
+            let score = score(from: row.emotion)
+
+            if let existing = latestByDay[day] {
+                if createdAt > existing.createdAt {
+                    latestByDay[day] = (score: score, createdAt: createdAt)
+                }
+            } else {
+                latestByDay[day] = (score: score, createdAt: createdAt)
+            }
+        }
+
+        let dayScores = latestByDay.values.map { $0.score }
+        let recordedDays = dayScores.count
+
+        // fallback: 파싱 실패로 dayScores가 비었으면 rows 기준으로 계산
+        let safeScores: [Int] = dayScores.isEmpty ? rows.map { score(from: $0.emotion) } : dayScores
+
+        let avgScore = max(1, min(5, Int(round(Double(safeScores.reduce(0, +)) / Double(max(1, safeScores.count))))))
+        let mostCommonScore = mostFrequentScore(in: safeScores) ?? avgScore
+
+        return WeeklyEmotionSummary(
+            emoji: emoji(for: mostCommonScore),
+            title: titleText(for: avgScore),
+            description: descriptionText(for: avgScore, recordedDays: recordedDays),
+            recordedDays: recordedDays
+        )
+    }
+
+    func mostFrequentScore(in scores: [Int]) -> Int? {
+        guard scores.isEmpty == false else { return nil }
+        let grouped = Dictionary(grouping: scores, by: { $0 })
+        return grouped.max { $0.value.count < $1.value.count }?.key
+    }
+
+    /// emotion(String?) → score(1~5)
+    /// 기준:
+    /// 5: 매우 긍정 (🥰)
+    /// 4: 긍정 (😊, 😌)
+    /// 3: 중립/사색 (🤔)
+    /// 2: 불안/부정 (😰, 😡)
+    /// 1: 매우 부정 (😢, 🤯)
+    func score(from emotion: String?) -> Int {
+        guard let e = emotion?.trimmingCharacters(in: .whitespacesAndNewlines), e.isEmpty == false else {
+            return 3
+        }
+
+        switch e {
+        case "🥰": return 5
+        case "😊", "😌": return 4
+        case "🤔": return 3
+        case "😰", "😡": return 2
+        case "😢", "🤯": return 1
+        default: return 3
+        }
+    }
+
+    func emoji(for score: Int) -> String {
+        switch score {
+        case 5: return "🥰"
+        case 4: return "😊"
+        case 3: return "🤔"
+        case 2: return "😰"
+        case 1: return "😢"
+        default: return "🤔"
+        }
+    }
+
+    func titleText(for avg: Int) -> String {
+        switch avg {
+        case 4...5:
+            return "꽤 좋은 한 주였어요"
+        case 3:
+            return "무난한 한 주였어요"
+        default:
+            return "조금 힘든 한 주였어요"
+        }
+    }
+
+    func descriptionText(for avg: Int, recordedDays: Int) -> String {
+        // 기록 일수에 따라 톤만 살짝 보정
+        let daysText = recordedDays == 0 ? "" : "(기록 \(recordedDays)일) "
+
+        switch avg {
+        case 4...5:
+            return daysText + "기분 좋은 날이 많았네요"
+        case 3:
+            return daysText + "큰 기복 없이 지나갔어요"
+        default:
+            return daysText + "스스로를 조금 더 챙겨줘도 좋아요"
+        }
+    }
+}

--- a/HaruDam/HaruDam/Repository/EmotionRecordRepository.swift
+++ b/HaruDam/HaruDam/Repository/EmotionRecordRepository.swift
@@ -1,0 +1,26 @@
+//
+//  EmotionRecordRepository.swift
+//  HaruDam
+//
+//  Created by 존진 on 1/24/26.
+//  Copyright © 2026 kr.co.HaruDam. All rights reserved.
+//
+
+import Foundation
+
+// 감정 기록 데이터 정의하는 프로토콜
+protocol EmotionRecordRepository {
+    
+    // Supabase에서 기간 범위로 감정 기록을 조회
+    func fetchRemoteRecords(from start: Date, to end: Date) async throws -> [RemoteEmotionRecord]
+    
+    // Supabase - insert 생성된 서버 id를 반환
+    func insert(record: EmotionRecordEntity) async throws -> String
+    
+    // Supabase - update
+    func update(record: EmotionRecordEntity) async throws
+    
+    // Supabase - delete
+    func delete(recordId: String) async throws
+    func delete(record: EmotionRecordEntity) async throws
+}

--- a/HaruDam/HaruDam/Repository/EmotionRecordRepository.swift
+++ b/HaruDam/HaruDam/Repository/EmotionRecordRepository.swift
@@ -23,4 +23,6 @@ protocol EmotionRecordRepository {
     // Supabase - delete
     func delete(recordId: String) async throws
     func delete(record: EmotionRecordEntity) async throws
+    
+    func fetchRecentRemoteRecords(limit: Int) async throws -> [RemoteEmotionRecord]
 }

--- a/HaruDam/HaruDam/Repository/RemoteEmotionRecord.swift
+++ b/HaruDam/HaruDam/Repository/RemoteEmotionRecord.swift
@@ -1,0 +1,21 @@
+//
+//  RemoteEmotionRecord.swift
+//  HaruDam
+//
+//  Created by 존진 on 1/24/26.
+//  Copyright © 2026 kr.co.HaruDam. All rights reserved.
+//
+
+import Foundation
+
+/// Supabase  emotion_records 테이블 조회 결과 DTO
+struct RemoteEmotionRecord: Decodable, Identifiable {
+    let id: String
+    let user_id: String?
+    let emotion: String?
+    let title: String?
+    let content: String?
+    let tags: [String]?
+    let created_at: String?
+    let updated_at: String?
+}

--- a/HaruDam/HaruDam/Services/EmotionRecordService.swift
+++ b/HaruDam/HaruDam/Services/EmotionRecordService.swift
@@ -138,4 +138,15 @@ final class EmotionRecordService: EmotionRecordRepository {
         guard let serverId = record.serverId, !serverId.isEmpty else { return }
         try await delete(recordId: serverId)
     }
+    
+    func fetchRecentRemoteRecords(limit: Int) async throws -> [RemoteEmotionRecord] {
+        let rows: [RemoteEmotionRecord] = try await supabase.client
+            .from("emotion_records")
+            .select("id, user_id, emotion, title, content, tags, created_at, updated_at")
+            .order("created_at", ascending: false)
+            .limit(limit)
+            .execute()
+            .value
+        return rows
+    }
 }

--- a/HaruDam/HaruDam/Services/EmotionRecordService.swift
+++ b/HaruDam/HaruDam/Services/EmotionRecordService.swift
@@ -10,7 +10,8 @@ import Foundation
 import Supabase
 import CoreData
 
-final class EmotionRecordService {
+final class EmotionRecordService: EmotionRecordRepository {
+    
     static let shared = EmotionRecordService()
     private let supabase: SupabaseManager
 
@@ -51,6 +52,22 @@ final class EmotionRecordService {
         f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         return f
     }()
+    
+    func fetchRemoteRecords(from start: Date, to end: Date) async throws -> [RemoteEmotionRecord] {
+        let startISO = isoFormatter.string(from: start)
+        let endISO = isoFormatter.string(from: end)
+
+        let rows: [RemoteEmotionRecord] = try await supabase.client
+            .from("emotion_records")
+            .select("id, user_id, emotion, title, content, tags, created_at, updated_at")
+            .gte("created_at", value: startISO)
+            .lt("created_at", value: endISO)
+            .order("created_at", ascending: true)
+            .execute()
+            .value
+
+        return rows
+    }
 
     /// Supabase - insert 생성된 서버 id(uuid)를 반환
     /// - Note: 테이블명은 `emotion_records`사용


### PR DESCRIPTION
## 🧩작업 내용
- 홈화면 UI 기능 개선
    - 기존 감정 흐름 차트 섹션 제거 -> 주간 감정 요약 카드 섹션 추가
    - 최근 담은 감정 리스트 섹션 구현
        - 서버에서 최근 감정 기록 최신순으로 조회(최대 N개(limit)만 로드)
- 데이터 로딩 및 UX 개선
    - 감정 기록 작성 화면 dismiss
        - 홈 화면 데이터 즉시 재로딩
- 아키텍처/구조
    - Repository 패턴 적용  

## 🚧 추후 작업할 내용 (미완성 부분)
<!-- 이슈 번호와 함께 향후 작업 예정인 내용을 작성해주세요 -->
<!-- 연결된 이슈가 있다면 작성해주세요 (예: #123) -->
<!-- 체크리스트 작성 (예: - [ ]) -->
- 

## 📷 스크린샷
<!-- UI 변경이 있는 경우 변경 전/후 스크린샷을 첨부해주세요 -->
<table>
  <tr>
    <td align="center">
<img src="https://github.com/user-attachments/assets/4a857290-64f6-486e-b807-8e7bb4959608" width="200"/><br>
      <p></p>
    </td>
  </tr>
</table>

## 🗒️ 기타 참고 사항
<!-- 리뷰어가 참고하면 좋을 추가 정보 -->
- 최근 감정 데이터는 서버에서 최신순 + limit으로 조회하여 성능을 우선 고려했습니다.
- 감정 이모지는 아래 기준으로 매핑됩니다.
	• 😌, 😊, 🥰 : 긍정
	• 🤔 : 중립
	• 😰, 😡 : 부정
	• 😢, 🤯 : 매우 부정